### PR TITLE
Alignak default arbiter name (amend #24)

### DIFF
--- a/alignak_backend_import/__init__.py
+++ b/alignak_backend_import/__init__.py
@@ -9,7 +9,7 @@
     an Alignak REST backend.
 """
 # Application version and manifest
-VERSION = (0, 4, 11, 'c')
+VERSION = (0, 4, 12)
 
 __application__ = u"Alignak backend import"
 __short_version__ = '.'.join((str(each) for each in VERSION[:2]))

--- a/alignak_backend_import/cfg_to_backend.py
+++ b/alignak_backend_import/cfg_to_backend.py
@@ -244,9 +244,12 @@ class CfgToBackend(object):
             # - debug_file
             # - config_name (new from 2016-08-06)
             try:
-                self.arbiter = Arbiter(cfg, False, False, False, False, '')
-            except TypeError:
                 self.arbiter = Arbiter(cfg, False, False, False, False, '', 'Default-Arbiter')
+            except TypeError:
+                try:
+                    self.arbiter = Arbiter(cfg, False, False, False, False, '', 'arbiter-master')
+                except TypeError:
+                    self.arbiter = Arbiter(cfg, False, False, False, False, '')
 
             self.arbiter.load_config_file()
 

--- a/alignak_backend_import/cfg_to_backend.py
+++ b/alignak_backend_import/cfg_to_backend.py
@@ -244,12 +244,9 @@ class CfgToBackend(object):
             # - debug_file
             # - config_name (new from 2016-08-06)
             try:
-                self.arbiter = Arbiter(cfg, False, False, False, False, '', 'Default-Arbiter')
+                self.arbiter = Arbiter(cfg, False, False, False, False, '', 'arbiter-master')
             except TypeError:
-                try:
-                    self.arbiter = Arbiter(cfg, False, False, False, False, '', 'arbiter-master')
-                except TypeError:
-                    self.arbiter = Arbiter(cfg, False, False, False, False, '')
+                self.arbiter = Arbiter(cfg, False, False, False, False, '')
 
             self.arbiter.load_config_file()
 
@@ -1112,7 +1109,7 @@ class CfgToBackend(object):
 
             # Special case of hosts
             if r_name == 'host':
-                item['freshness_state'] = 'DOWN'
+                #item['freshness_state'] = 'DOWN'
                 if self.models and item_obj.is_tpl():
                     item['_is_template'] = True
                     if 'check_command' not in item:
@@ -1145,7 +1142,7 @@ class CfgToBackend(object):
 
             # Special case of services
             if r_name == 'service':
-                item['freshness_state'] = 'WARNING'
+                #item['freshness_state'] = 'WARNING'
                 if self.models and item_obj.is_tpl():
                     item['_is_template'] = True
                     item['host'] = ''

--- a/alignak_backend_import/cfg_to_backend.py
+++ b/alignak_backend_import/cfg_to_backend.py
@@ -1109,7 +1109,7 @@ class CfgToBackend(object):
 
             # Special case of hosts
             if r_name == 'host':
-                #item['freshness_state'] = 'DOWN'
+                # item['freshness_state'] = 'DOWN'
                 if self.models and item_obj.is_tpl():
                     item['_is_template'] = True
                     if 'check_command' not in item:
@@ -1142,7 +1142,7 @@ class CfgToBackend(object):
 
             # Special case of services
             if r_name == 'service':
-                #item['freshness_state'] = 'WARNING'
+                # item['freshness_state'] = 'WARNING'
                 if self.models and item_obj.is_tpl():
                     item['_is_template'] = True
                     item['host'] = ''


### PR DESCRIPTION
Alignak default arbiter name is:

 - `Default-Arbiter` if no arbiter configuration found

 - `master-arbiter` in the default installed configuration

 We must try to load both cases, and not only the first one.