### PR TITLE
Update for new Alignak arbiter class interface

### DIFF
--- a/alignak_backend_import/__init__.py
+++ b/alignak_backend_import/__init__.py
@@ -9,7 +9,7 @@
     an Alignak REST backend.
 """
 # Application version and manifest
-VERSION = (0, 5, 6)
+VERSION = (0, 6, 0)
 
 __application__ = u"Alignak backend import"
 __short_version__ = '.'.join((str(each) for each in VERSION[:2]))

--- a/alignak_backend_import/cfg_to_backend.py
+++ b/alignak_backend_import/cfg_to_backend.py
@@ -234,7 +234,8 @@ class CfgToBackend(object):
         print("Default host location: %s" % self.gps)
 
         # Alignak arbiter configuration
-        # - configuration
+        # - daemon configuration file
+        # - monitoring configuration files list
         # - is_daemon
         # - do_replace
         # - verify_only
@@ -243,27 +244,45 @@ class CfgToBackend(object):
         # - config_name (new from 2016-08-06)
         # - analyse=None
         # pylint: disable=too-many-function-args
+        self.raw_conf = None
         try:
             # Try new Arbiter signature...
-            self.arbiter = Arbiter(cfg, False, False, False, False, '', 'arbiter-master', None)
-        except Exception as e:
-            # Try old Arbiter signature
-            self.arbiter = Arbiter(cfg, False, False, False, False, '', None)
+            self.arbiter = Arbiter(None, cfg,
+                                   False, False, False, False, '', 'arbiter-master', None)
 
-        try:
+            # Configure the logger
+            self.arbiter.setup_alignak_logger()
+
             # Get flat files configuration
-            self.arbiter.load_config_file()
+            self.arbiter.load_monitoring_config_file()
 
             # Raw configuration
             self.raw_conf = Config()
             buf = self.raw_conf.read_config(cfg)
             self.raw_objects = self.raw_conf.read_config_buf(buf)
         except Exception as e:
-            print("Configuration loading exception: %s" % str(e))
-            print("***** Traceback: %s", traceback.format_exc())
-            print("~~~~~~~~~~~~~~~~~~~~~~~~~~")
-            print("Exiting with error code: 3")
-            self.exit(3)
+            # Try old Arbiter signature
+            self.arbiter = Arbiter(cfg,
+                                   False, False, False, False, '', 'arbiter-master', None)
+
+        if not self.raw_conf:
+            try:
+                # Configure the logger
+                self.arbiter.setup_alignak_logger()
+
+                # Get flat files configuration
+                self.arbiter.load_config_file()
+
+                # Raw configuration
+                self.raw_conf = Config()
+                buf = self.raw_conf.read_config(cfg)
+                self.raw_objects = self.raw_conf.read_config_buf(buf)
+            except Exception as e:
+                print("Configuration loading exception: %s" % str(e))
+                print("***** Traceback: %s", traceback.format_exc())
+                print("~~~~~~~~~~~~~~~~~~~~~~~~~~")
+                print("Exiting with error code: 3")
+                self.exit(3)
 
         end = time.time()
         print("Elapsed time after Arbiter has loaded the configuration: %s" % (end - start))
@@ -2341,6 +2360,15 @@ def main():
 
     end = time.time()
     print("Global configuration import duration: %s" % (end - start))
+
+
+def main_old():
+    """
+    Main function - deprecated script name
+    """
+    print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
+    print("alignak_backend_import is deprecated. Use the new 'alignak-backend-import' script.")
+    print("~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~")
 
 if __name__ == "__main__":  # pragma: no cover
     main()

--- a/setup.py
+++ b/setup.py
@@ -101,7 +101,8 @@ setup(
 
     entry_points={
         'console_scripts': [
-            'alignak_backend_import = alignak_backend_import.cfg_to_backend:main',
+            'alignak_backend_import = alignak_backend_import.cfg_to_backend:main_old',
+            'alignak-backend-import = alignak_backend_import.cfg_to_backend:main'
         ],
     },
 

--- a/test/alignak_cfg_files/alignak_most_recent/alignak.backend-import.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/alignak.backend-import.cfg
@@ -1,0 +1,268 @@
+# --------------------------------------------------------------------
+# Alignak main configuration file
+# --------------------------------------------------------------------
+# This file is the main file that will be loaded by Alignak on boot.
+# It is the entry point for the framework configuration.
+# --------------------------------------------------------------------
+# Please see the official project documentation for documentation about
+# the configuration:
+# http://alignak-doc.readthedocs.io/en/latest/04_configuration/index.html
+# --------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+# Monitored objects configuration part
+# -------------------------------------------------------------------------
+# Configuration files with common objects like commands, timeperiods,
+# or templates that are used by the host/service/contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+cfg_dir=arbiter/objects/realms
+cfg_dir=arbiter/objects/commands
+cfg_dir=arbiter/objects/timeperiods
+cfg_dir=arbiter/objects/escalations
+cfg_dir=arbiter/objects/dependencies
+
+# Templates and packs for hosts, services and contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+cfg_dir=arbiter/templates
+cfg_dir=arbiter/packs
+
+# Notification ways
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+cfg_dir=arbiter/objects/notificationways
+
+# Groups
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+cfg_dir=arbiter/objects/servicegroups
+cfg_dir=arbiter/objects/hostgroups
+cfg_dir=arbiter/objects/contactgroups
+
+# Real hosts, services and contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+cfg_dir=arbiter/objects/hosts
+cfg_dir=arbiter/objects/services
+cfg_dir=arbiter/objects/contacts
+
+# Alignak daemons and modules are loaded
+cfg_dir=arbiter/daemons
+cfg_dir=arbiter/modules
+
+# Alignak extra realms
+cfg_dir=arbiter/realms
+
+# You will find global MACROS into the files in those directories
+cfg_dir=arbiter/resource.d
+cfg_dir=arbiter/packs/resource.d
+
+# -------------------------------------------------------------------------
+# Alignak framework configuration part
+# -------------------------------------------------------------------------
+
+# Notifications configuration
+# ---
+# Notifications are enabled/disabled
+# enable_notifications=1
+
+# After a timeout, launched plugins are killed
+#notification_timeout=30
+
+
+# Retention configuration
+# ---
+# Number of minutes between 2 retention save, default is 60 minutes
+#retention_update_interval=60
+
+# Checks configuration
+# ---
+# Active host/service checks are enabled/disabled
+#execute_host_checks=1
+#execute_service_checks=1
+
+# Passive host/service checks are enabled/disabled
+#accept_passive_host_checks=1
+#accept_passive_service_checks=1
+
+# As default, passive host checks are HARD states
+#passive_host_checks_are_soft=0
+
+
+# Interval length and re-scheduling configuration
+# Do not change those values unless you are reaaly sure to master what you are doing ...
+#interval_length=60
+#auto_reschedule_checks=1
+auto_rescheduling_interval=1
+auto_rescheduling_window=180
+use_aggressive_host_checking=0
+
+
+# Number of interval to spread the first checks for hosts and services
+# Default is 30
+#max_service_check_spread=30
+max_service_check_spread=5
+# Default is 30
+#max_host_check_spread=30
+max_host_check_spread=5
+
+
+# Max plugin output for the plugins launched by the pollers, in bytes
+#max_plugins_output_length=8192
+max_plugins_output_length=65536
+
+
+# After a timeout, launched plugins are killed
+# and the host state is set to a default value (2 for DOWN)
+# and the service state is set to a default value (2 for CRITICAL)
+#host_check_timeout=30
+#service_check_timeout=60
+#timeout_exit_status=2
+#event_handler_timeout=30
+#notification_timeout=30
+#ocsp_timeout=15
+#ohsp_timeout=15
+
+
+# Freshness check
+# Default is enabled for hosts and services
+#check_host_freshness=1
+#check_service_freshness=1
+# Default is 60 for hosts and services
+#host_freshness_check_interval=60
+#service_freshness_check_interval=60
+# Extra time for freshness check ...
+#additional_freshness_latency=15
+
+
+# Flapping detection configuration
+# ---
+# Default is enabled
+#enable_flap_detection=1
+
+# Flapping threshold for hosts and services
+#low_service_flap_threshold=20
+#high_service_flap_threshold=30
+#low_host_flap_threshold=20
+#high_host_flap_threshold=30
+
+# flap_history is the lengh of history states we keep to look for flapping.
+# 20 by default, can be useful to increase it. Each flap_history increases cost:
+#    flap_history cost = 4Bytes * flap_history * (nb hosts + nb services)
+# Example: 4 * 20 * (1000+10000) ~ 900Ko for a quite big conf. So, go for it!
+#flap_history=20
+
+
+# Performance data configuration
+# ---
+# Performance data management is enabled/disabled
+#process_performance_data=1
+
+# Performance data commands
+#host_perfdata_command=
+#service_perfdata_command=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# Event handlers configuration
+# ---
+# Event handlers are enabled/disabled
+#enable_event_handlers=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+# Global host/service event handlers
+#global_host_event_handler=
+#global_service_event_handler=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# External commands configuration
+# ---
+# External commands are enabled/disabled
+# check_external_commands=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+
+# Impacts configuration
+# ---
+# Enable or not the state change on impact detection (like a host going unreachable
+# if a parent is DOWN for example). It's for services and hosts.
+# Note: defaults to 0 for Nagios old behavior compatibility
+#enable_problem_impacts_states_change=0
+enable_problem_impacts_states_change=1
+
+
+# if 1, disable all notice and warning messages at
+# configuration checking when arbiter checks the configuration.
+# Default is to log the notices and warnings
+#disable_old_nagios_parameters_whining=0
+disable_old_nagios_parameters_whining=1
+
+
+# Environment macros configuration
+# ---
+# Disabling environment macros is good for performance. If you really need it, enable it.
+#enable_environment_macros=1
+enable_environment_macros=0
+
+
+# Monitoring log configuration
+# ---
+# Notifications
+# log_notifications=1
+
+# Services retries
+# log_service_retries=1
+
+# Hosts retries
+# log_host_retries=1
+
+# Event handlers
+# log_event_handlers=1
+
+# External commands
+# log_external_commands=1
+
+# Passive checks
+# log_passive_checks=1
+
+# Initial states
+# log_initial_states=1
+
+
+# [Optional], a pack distribution file is a local file near the arbiter
+# that will keep host pack id association, and so push same host on the same
+# scheduler if possible between restarts.
+pack_distribution_file=/usr/local/var/lib/alignak/pack_distribution.dat
+
+
+# If you need to set a specific timezone to your deamons, uncomment it
+#use_timezone=Europe/Paris
+
+
+# Export all alignak inner performances into a statsd server.
+# By default at localhost:8125 (UDP) with the alignak prefix
+# Default is not enabled
+#statsd_host=localhost
+#statsd_port=8125
+#statsd_prefix=alignak
+#statsd_enabled=0
+
+
+# --------------------------------------------------------------------
+## Arbiter daemon part, similar to daemon ini file
+# --------------------------------------------------------------------
+#
+# Those parameters are defined in the arbiterd.ini file
+# 

--- a/test/alignak_cfg_files/alignak_most_recent/alignak.backend-run.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/alignak.backend-run.cfg
@@ -1,0 +1,264 @@
+# --------------------------------------------------------------------
+# Alignak backend objects loading configuration file
+# --------------------------------------------------------------------
+# This file is a sample file that can be used to load all the 
+# configuration from an Alignak backend.
+# --------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+# Monitored objects configuration part
+# -------------------------------------------------------------------------
+# Configuration files with common objects like commands, timeperiods,
+# or templates that are used by the host/service/contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/objects/realms
+; cfg_dir=arbiter/objects/commands
+; cfg_dir=arbiter/objects/timeperiods
+; cfg_dir=arbiter/objects/escalations
+; cfg_dir=arbiter/objects/dependencies
+
+# Templates and packs for hosts, services and contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/templates
+; cfg_dir=arbiter/packs
+
+# Notification ways
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/objects/notificationways
+
+# Groups
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/objects/servicegroups
+; cfg_dir=arbiter/objects/hostgroups
+; cfg_dir=arbiter/objects/contactgroups
+
+# Real hosts, services and contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/objects/hosts
+; cfg_dir=arbiter/objects/services
+; cfg_dir=arbiter/objects/contacts
+
+# Alignak daemons and modules are loaded
+cfg_dir=arbiter/daemons
+cfg_dir=arbiter/modules
+
+# Alignak extra realms
+cfg_dir=arbiter/realms
+
+# You will find global MACROS into the files in those directories
+cfg_dir=arbiter/resource.d
+cfg_dir=arbiter/packs/resource.d
+
+# -------------------------------------------------------------------------
+# Alignak framework configuration part
+# -------------------------------------------------------------------------
+
+# Notifications configuration
+# ---
+# Notifications are enabled/disabled
+# enable_notifications=1
+
+# After a timeout, launched plugins are killed
+#notification_timeout=30
+
+
+# Retention configuration
+# ---
+# Number of minutes between 2 retention save, default is 60 minutes
+#retention_update_interval=60
+
+# Checks configuration
+# ---
+# Active host/service checks are enabled/disabled
+#execute_host_checks=1
+#execute_service_checks=1
+
+# Passive host/service checks are enabled/disabled
+#accept_passive_host_checks=1
+#accept_passive_service_checks=1
+
+# As default, passive host checks are HARD states
+#passive_host_checks_are_soft=0
+
+
+# Interval length and re-scheduling configuration
+# Do not change those values unless you are reaaly sure to master what you are doing ...
+#interval_length=60
+#auto_reschedule_checks=1
+auto_rescheduling_interval=1
+auto_rescheduling_window=180
+use_aggressive_host_checking=0
+
+
+# Number of interval to spread the first checks for hosts and services
+# Default is 30
+#max_service_check_spread=30
+max_service_check_spread=5
+# Default is 30
+#max_host_check_spread=30
+max_host_check_spread=5
+
+
+# Max plugin output for the plugins launched by the pollers, in bytes
+#max_plugins_output_length=8192
+max_plugins_output_length=65536
+
+
+# After a timeout, launched plugins are killed
+# and the host state is set to a default value (2 for DOWN)
+# and the service state is set to a default value (2 for CRITICAL)
+#host_check_timeout=30
+#service_check_timeout=60
+#timeout_exit_status=2
+#event_handler_timeout=30
+#notification_timeout=30
+#ocsp_timeout=15
+#ohsp_timeout=15
+
+
+# Freshness check
+# Default is enabled for hosts and services
+#check_host_freshness=1
+#check_service_freshness=1
+# Default is 60 for hosts and services
+#host_freshness_check_interval=60
+#service_freshness_check_interval=60
+# Extra time for freshness check ...
+#additional_freshness_latency=15
+
+
+# Flapping detection configuration
+# ---
+# Default is enabled
+#enable_flap_detection=1
+
+# Flapping threshold for hosts and services
+#low_service_flap_threshold=20
+#high_service_flap_threshold=30
+#low_host_flap_threshold=20
+#high_host_flap_threshold=30
+
+# flap_history is the lengh of history states we keep to look for flapping.
+# 20 by default, can be useful to increase it. Each flap_history increases cost:
+#    flap_history cost = 4Bytes * flap_history * (nb hosts + nb services)
+# Example: 4 * 20 * (1000+10000) ~ 900Ko for a quite big conf. So, go for it!
+#flap_history=20
+
+
+# Performance data configuration
+# ---
+# Performance data management is enabled/disabled
+#process_performance_data=1
+
+# Performance data commands
+#host_perfdata_command=
+#service_perfdata_command=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# Event handlers configuration
+# ---
+# Event handlers are enabled/disabled
+#enable_event_handlers=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+# Global host/service event handlers
+#global_host_event_handler=
+#global_service_event_handler=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# External commands configuration
+# ---
+# External commands are enabled/disabled
+# check_external_commands=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+
+# Impacts configuration
+# ---
+# Enable or not the state change on impact detection (like a host going unreachable
+# if a parent is DOWN for example). It's for services and hosts.
+# Note: defaults to 0 for Nagios old behavior compatibility
+#enable_problem_impacts_states_change=0
+enable_problem_impacts_states_change=1
+
+
+# if 1, disable all notice and warning messages at
+# configuration checking when arbiter checks the configuration.
+# Default is to log the notices and warnings
+#disable_old_nagios_parameters_whining=0
+disable_old_nagios_parameters_whining=1
+
+
+# Environment macros configuration
+# ---
+# Disabling environment macros is good for performance. If you really need it, enable it.
+#enable_environment_macros=1
+enable_environment_macros=0
+
+
+# Monitoring log configuration
+# ---
+# Notifications
+# log_notifications=1
+
+# Services retries
+# log_service_retries=1
+
+# Hosts retries
+# log_host_retries=1
+
+# Event handlers
+# log_event_handlers=1
+
+# External commands
+# log_external_commands=1
+
+# Passive checks
+# log_passive_checks=1
+
+# Initial states
+# log_initial_states=1
+
+
+# [Optional], a pack distribution file is a local file near the arbiter
+# that will keep host pack id association, and so push same host on the same
+# scheduler if possible between restarts.
+pack_distribution_file=/usr/local/var/lib/alignak/pack_distribution.dat
+
+
+# If you need to set a specific timezone to your deamons, uncomment it
+#use_timezone=Europe/Paris
+
+
+# Export all alignak inner performances into a statsd server.
+# By default at localhost:8125 (UDP) with the alignak prefix
+# Default is not enabled
+#statsd_host=localhost
+#statsd_port=8125
+#statsd_prefix=alignak
+#statsd_enabled=0
+
+
+# --------------------------------------------------------------------
+## Arbiter daemon part, similar to daemon ini file
+# --------------------------------------------------------------------
+#
+# Those parameters are defined in the arbiterd.ini file
+# 

--- a/test/alignak_cfg_files/alignak_most_recent/alignak.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/alignak.cfg
@@ -1,0 +1,264 @@
+# --------------------------------------------------------------------
+# Alignak backend objects loading configuration file
+# --------------------------------------------------------------------
+# This file is a sample file that can be used to load all the 
+# configuration from an Alignak backend.
+# --------------------------------------------------------------------
+
+# -------------------------------------------------------------------------
+# Monitored objects configuration part
+# -------------------------------------------------------------------------
+# Configuration files with common objects like commands, timeperiods,
+# or templates that are used by the host/service/contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/objects/realms
+; cfg_dir=arbiter/objects/commands
+; cfg_dir=arbiter/objects/timeperiods
+; cfg_dir=arbiter/objects/escalations
+; cfg_dir=arbiter/objects/dependencies
+
+# Templates and packs for hosts, services and contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/templates
+; cfg_dir=arbiter/packs
+
+# Notification ways
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/objects/notificationways
+
+# Groups
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/objects/servicegroups
+; cfg_dir=arbiter/objects/hostgroups
+; cfg_dir=arbiter/objects/contactgroups
+
+# Real hosts, services and contacts
+; When loading data only from the alignak backend, comment this
+; block because data do not need to be read from files
+; cfg_dir=arbiter/objects/hosts
+; cfg_dir=arbiter/objects/services
+; cfg_dir=arbiter/objects/contacts
+
+# Alignak daemons and modules are loaded
+cfg_dir=arbiter/daemons
+cfg_dir=arbiter/modules
+
+# Alignak extra realms
+cfg_dir=arbiter/realms
+
+# You will find global MACROS into the files in those directories
+cfg_dir=arbiter/resource.d
+cfg_dir=arbiter/packs/resource.d
+
+# -------------------------------------------------------------------------
+# Alignak framework configuration part
+# -------------------------------------------------------------------------
+
+# Notifications configuration
+# ---
+# Notifications are enabled/disabled
+# enable_notifications=1
+
+# After a timeout, launched plugins are killed
+#notification_timeout=30
+
+
+# Retention configuration
+# ---
+# Number of minutes between 2 retention save, default is 60 minutes
+#retention_update_interval=60
+
+# Checks configuration
+# ---
+# Active host/service checks are enabled/disabled
+#execute_host_checks=1
+#execute_service_checks=1
+
+# Passive host/service checks are enabled/disabled
+#accept_passive_host_checks=1
+#accept_passive_service_checks=1
+
+# As default, passive host checks are HARD states
+#passive_host_checks_are_soft=0
+
+
+# Interval length and re-scheduling configuration
+# Do not change those values unless you are reaaly sure to master what you are doing ...
+#interval_length=60
+#auto_reschedule_checks=1
+auto_rescheduling_interval=1
+auto_rescheduling_window=180
+use_aggressive_host_checking=0
+
+
+# Number of interval to spread the first checks for hosts and services
+# Default is 30
+#max_service_check_spread=30
+max_service_check_spread=5
+# Default is 30
+#max_host_check_spread=30
+max_host_check_spread=5
+
+
+# Max plugin output for the plugins launched by the pollers, in bytes
+#max_plugins_output_length=8192
+max_plugins_output_length=65536
+
+
+# After a timeout, launched plugins are killed
+# and the host state is set to a default value (2 for DOWN)
+# and the service state is set to a default value (2 for CRITICAL)
+#host_check_timeout=30
+#service_check_timeout=60
+#timeout_exit_status=2
+#event_handler_timeout=30
+#notification_timeout=30
+#ocsp_timeout=15
+#ohsp_timeout=15
+
+
+# Freshness check
+# Default is enabled for hosts and services
+#check_host_freshness=1
+#check_service_freshness=1
+# Default is 60 for hosts and services
+#host_freshness_check_interval=60
+#service_freshness_check_interval=60
+# Extra time for freshness check ...
+#additional_freshness_latency=15
+
+
+# Flapping detection configuration
+# ---
+# Default is enabled
+#enable_flap_detection=1
+
+# Flapping threshold for hosts and services
+#low_service_flap_threshold=20
+#high_service_flap_threshold=30
+#low_host_flap_threshold=20
+#high_host_flap_threshold=30
+
+# flap_history is the lengh of history states we keep to look for flapping.
+# 20 by default, can be useful to increase it. Each flap_history increases cost:
+#    flap_history cost = 4Bytes * flap_history * (nb hosts + nb services)
+# Example: 4 * 20 * (1000+10000) ~ 900Ko for a quite big conf. So, go for it!
+#flap_history=20
+
+
+# Performance data configuration
+# ---
+# Performance data management is enabled/disabled
+#process_performance_data=1
+
+# Performance data commands
+#host_perfdata_command=
+#service_perfdata_command=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# Event handlers configuration
+# ---
+# Event handlers are enabled/disabled
+#enable_event_handlers=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+# Global host/service event handlers
+#global_host_event_handler=
+#global_service_event_handler=
+
+# After a timeout, launched plugins are killed
+#event_handler_timeout=30
+
+
+# External commands configuration
+# ---
+# External commands are enabled/disabled
+# check_external_commands=1
+
+# By default don't launch even handlers during downtime. Put 0 to
+# get back the default nagios behavior
+no_event_handlers_during_downtimes=1
+
+
+# Impacts configuration
+# ---
+# Enable or not the state change on impact detection (like a host going unreachable
+# if a parent is DOWN for example). It's for services and hosts.
+# Note: defaults to 0 for Nagios old behavior compatibility
+#enable_problem_impacts_states_change=0
+enable_problem_impacts_states_change=1
+
+
+# if 1, disable all notice and warning messages at
+# configuration checking when arbiter checks the configuration.
+# Default is to log the notices and warnings
+#disable_old_nagios_parameters_whining=0
+disable_old_nagios_parameters_whining=1
+
+
+# Environment macros configuration
+# ---
+# Disabling environment macros is good for performance. If you really need it, enable it.
+#enable_environment_macros=1
+enable_environment_macros=0
+
+
+# Monitoring log configuration
+# ---
+# Notifications
+# log_notifications=1
+
+# Services retries
+# log_service_retries=1
+
+# Hosts retries
+# log_host_retries=1
+
+# Event handlers
+# log_event_handlers=1
+
+# External commands
+# log_external_commands=1
+
+# Passive checks
+# log_passive_checks=1
+
+# Initial states
+# log_initial_states=1
+
+
+# [Optional], a pack distribution file is a local file near the arbiter
+# that will keep host pack id association, and so push same host on the same
+# scheduler if possible between restarts.
+pack_distribution_file=/usr/local/var/lib/alignak/pack_distribution.dat
+
+
+# If you need to set a specific timezone to your deamons, uncomment it
+#use_timezone=Europe/Paris
+
+
+# Export all alignak inner performances into a statsd server.
+# By default at localhost:8125 (UDP) with the alignak prefix
+# Default is not enabled
+#statsd_host=localhost
+#statsd_port=8125
+#statsd_prefix=alignak
+#statsd_enabled=0
+
+
+# --------------------------------------------------------------------
+## Arbiter daemon part, similar to daemon ini file
+# --------------------------------------------------------------------
+#
+# Those parameters are defined in the arbiterd.ini file
+# 

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/arbiter-master.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/arbiter-master.cfg
@@ -1,0 +1,43 @@
+#===============================================================================
+# ARBITER
+#===============================================================================
+# Description: The Arbiter is responsible for:
+# - Loading, manipulating and dispatching the configuration
+# - Validating the health of all other Alignak daemons
+# - Issuing global directives to Alignak daemons (kill, activate-spare, etc.)
+# https://alignak.readthedocs.org/en/latest/08_configobjects/arbiter.html
+#===============================================================================
+# IMPORTANT: If you use several arbiters you MUST set the host_name on each
+# servers to its real DNS name ('hostname' command).
+#===============================================================================
+define arbiter {
+    arbiter_name            arbiter-master
+    #host_name              node1           ; CHANGE THIS if you have several Arbiters (like with a spare)
+    address                 127.0.0.1
+    port                    7770
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    ## Interesting modules:
+    # - backend_arbiter     = get the monitored objects configuration from the Alignak backend
+    modules                 backend_arbiter
+
+    ## Optional parameters:
+    ## Uncomment these lines in a HA architecture so the master and slaves know
+    ## how long they may wait for each other.
+    #timeout                 3   ; Ping timeout
+    #data_timeout            120 ; Data send timeout
+    #max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    #check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/broker-master.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/broker-master.cfg
@@ -1,0 +1,47 @@
+#===============================================================================
+# BROKER (S1_Broker)
+#===============================================================================
+# Description: The broker is responsible for:
+# - Exporting centralized logs of all Alignak daemon processes
+# - Exporting status data
+# - Exporting performance data
+# - Exposing Alignak APIs:
+#   - Status data
+#   - Performance data
+#   - Configuration data
+#   - Command interface
+# https://alignak.readthedocs.org/en/latest/08_configobjects/broker.html
+#===============================================================================
+define broker {
+    broker_name             broker-master
+    address                 127.0.0.1
+    port                    7772
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_broker      = update the live state in the Alignak backend
+    modules                 backend_broker
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_arbiters         1   ; Take data from Arbiter. There should be only one
+                                ; broker for the arbiter.
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/poller-master.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/poller-master.cfg
@@ -1,0 +1,57 @@
+#===============================================================================
+# POLLER (S1_Poller)
+#===============================================================================
+# Description: The poller is responsible for:
+# - Active data acquisition
+# - Local passive data acquisition
+# https://alignak.readthedocs.org/en/latest/08_configobjects/poller.html
+#===============================================================================
+define poller {
+    poller_name             poller-master
+    address                 127.0.0.1
+    port                    7771
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    ## Interesting modules:
+    # - booster-nrpe        = Replaces the check_nrpe binary. Therefore it
+    #                       enhances performances when there are lot of NRPE
+    #                       calls.
+    # - named-pipe          = Allow the poller to read a nagios.cmd named pipe.
+    #                       This permits the use of distributed check_mk checks
+    #                       should you desire it.
+    # - snmp-booster        = Snmp bulk polling module
+    modules
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    ## In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+    min_workers             0   ; Starts with N processes (0 = 1 per CPU)
+    max_workers             0   ; No more than N processes (0 = 1 per CPU)
+    processes_by_worker     256 ; Each worker manages N checks
+    polling_interval        1   ; Get jobs from schedulers each N seconds
+
+    #passive                0   ; For DMZ monitoring, set to 1 so the connections
+                                ; will be from scheduler -> poller.
+
+    # Poller tags are the tag that the poller will manage. Use None as tag name to manage
+    # untagged checks
+    #poller_tags             None
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/reactionner-master.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/reactionner-master.cfg
@@ -1,0 +1,45 @@
+#===============================================================================
+# REACTIONNER (S1_Reactionner)
+#===============================================================================
+# Description: The reactionner is responsible for:
+# - Executing notification actions
+# - Executing event handler actions
+# https://alignak.readthedocs.org/en/latest/08_configobjects/reactionner.html
+#===============================================================================
+define reactionner {
+    reactionner_name        reactionner-master
+    address                 127.0.0.1
+    port                    7769
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    modules
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+    min_workers             1   ; Starts with N processes (0 = 1 per CPU)
+    max_workers             15  ; No more than N processes (0 = 1 per CPU)
+    polling_interval        1   ; Get jobs from schedulers each 1 second
+
+    # Reactionner tags are the tag that the reactionner will manage. Use None as tag name to manage
+    # untagged notification/event handlers
+    #reactionner_tags        None
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/receiver-master.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/receiver-master.cfg
@@ -1,0 +1,41 @@
+#===============================================================================
+# RECEIVER
+#===============================================================================
+# The receiver manages passive information. It's just a "buffer" which will
+# load passive modules (like NSCA) and be read by the arbiter to dispatch data.
+#===============================================================================
+define receiver {
+    receiver_name           receiver-master
+    address                 127.0.0.1
+    port                    7773
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - nsca                = NSCA protocol server for collecting passive checks
+    modules                 nsca
+
+    ## Optional parameters
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Feature
+    direct_routing          1   ; If enabled, it will directly send commands to the
+                                ; schedulers if it knows about the hostname in the
+                                ; command.
+                                ; If not the arbiter will get the information from
+                                ; the receiver.
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/scheduler-master.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/daemons/scheduler-master.cfg
@@ -1,0 +1,54 @@
+#===============================================================================
+# SCHEDULER (S1_Scheduler)
+#===============================================================================
+# The scheduler is a "Host manager". It gets the hosts and their services,
+# schedules the checks and transmit them to the pollers.
+# Description: The scheduler is responsible for:
+# - Creating the dependancy tree
+# - Scheduling checks
+# - Calculating states
+# - Requesting actions from a reactionner
+# - Buffering and forwarding results its associated broker
+# https://alignak.readthedocs.org/en/latest/08_configobjects/scheduler.html
+#===============================================================================
+define scheduler {
+    scheduler_name          scheduler-master
+    address                 127.0.0.1
+    port                    7768
+
+    ## Realm
+    #realm                   All
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_scheduler   = store the live state in the Alignak backend (retention)
+    #modules                 backend_scheduler
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Features:
+    # Skip initial broks creation. Boot fast, but some broker modules won't
+    # work with it! (like livestatus for example)
+    skip_initial_broks      0
+
+    # Some schedulers can manage more hosts than others
+    weight                  1
+
+    # In NATted environments, you declare each satellite ip[:port] as seen by
+    # *this* scheduler (if port not set, the port declared by satellite itself
+    # is used)
+    #satellitemap    poller-1=1.2.3.4:7771, reactionner-1=1.2.3.5:7769, ...
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/modules/mod-alignak_backend_arbiter.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/modules/mod-alignak_backend_arbiter.cfg
@@ -1,0 +1,28 @@
+define module {
+    module_alias            backend_arbiter
+    python_name             alignak_module_backend.arbiter
+
+    # Backend endpoint URL
+    api_url                 http://127.0.0.1:5000
+
+    # Backend authentication:
+    # [Method 1] Use token directly
+    # token                 1442583814636-bed32565-2ff7-4023-87fb-34a3ac93d34c
+    # [Method 2] Use username + password
+    username              admin
+    password              admin
+    # On login, force a new token generation
+    # allowgeneratetoken    false
+
+    # Bypass the objects loading when arbiter is in verify mode
+    # Default, 0 (do not bypass)
+    #bypass_verify_mode      0
+
+    # check every x min if config in backend changed, if yes it will reload it
+    # Default, every 5 minutes
+    #verify_modification     5
+
+    # Check every x seconds if have actions in backend (acknowledge, downtimes, recheck...)
+    # Default, every 15 seconds
+    #action_check            15
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/modules/mod-alignak_backend_broker.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/modules/mod-alignak_backend_broker.cfg
@@ -1,0 +1,16 @@
+define module {
+    module_alias            backend_broker
+    python_name             alignak_module_backend.broker
+
+    # Backend endpoint URL
+    api_url                 http://127.0.0.1:5000
+
+    # Backend authentication:
+    # [Method 1] Use token directly
+    # token                 1442583814636-bed32565-2ff7-4023-87fb-34a3ac93d34c
+    # [Method 2] Use username + password
+    username              admin
+    password              admin
+    # On login, force a new token generation
+    # allowgeneratetoken    false
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/modules/mod-alignak_backend_scheduler.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/modules/mod-alignak_backend_scheduler.cfg
@@ -1,0 +1,16 @@
+define module {
+    module_alias            backend_scheduler
+    python_name             alignak_module_backend.scheduler
+
+    # Backend endpoint URL
+    api_url                 http://127.0.0.1:5000
+
+    # Backend authentication:
+    # [Method 1] Use token directly
+    # token                 1442583814636-bed32565-2ff7-4023-87fb-34a3ac93d34c
+    # [Method 2] Use username + password
+    username              admin
+    password              admin
+    # On login, force a new token generation
+    # allowgeneratetoken    false
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/modules/mod-nsca.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/modules/mod-nsca.cfg
@@ -1,0 +1,47 @@
+## Module:      nsca
+## Loaded by:   Receiver
+# Receive check results sent with NSCA protocol.
+define module {
+    module_alias             nsca
+    python_name              alignak_module_nsca
+
+    # Default is listening on all address, TCP port 5667
+    host                    *
+    port                    15667
+
+    # Encryption method:
+    # 0 for no encryption (default)
+    # 1 for simple Xor
+    # No other encryption method available!
+    encryption_method       0
+    password                helloworld
+
+    # Maximum packet age defines the maximum delay
+    # (in seconds) for a packet to be considered as staled
+    max_packet_age          60
+
+    # If check_future_packet attribute is defined, packets
+    # more recent than current timestamp are dropped
+    check_future_packet     1
+
+    # Payload length is length of effective data sent :
+    # . -1 to accept any payload length
+    # . 512 or 4096 depending upon NSCA client configuration
+    # If packet payload is not the right size, packet is dropped
+    payload_length          -1
+
+    # Buffer length is maximum length of received data :
+    # should be greater than payload length
+    # Default is 8192
+    #buffer_length           8192
+
+    # backlog is the maximum number of concurrent sockets
+    # Default is 10
+    #backlog                 10
+
+    # Packet output decoding codec
+    # NSCA packet output is decoded with this codec. Set this parameter to the right value
+    # for NSCA client using specific codecs for sending output data
+    # Default is UTF-8
+    #output_decoding         UTF-8
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/commands/detailled-host-by-email.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/commands/detailled-host-by-email.cfg
@@ -1,0 +1,6 @@
+## Notify Host by Email with detailled informations
+# Service have appropriate macros. Look at unix-fs pack to get an example
+define command {
+    command_name    detailled-host-by-email
+    command_line    /usr/bin/printf "%b" "Alignak Notification\n\nType:$NOTIFICATIONTYPE$\nHost: $HOSTNAME$\nState: $HOSTSTATE$\nAddress: $HOSTADDRESS$\nDate/Time: $DATE$/$TIME$\n Host Output : $HOSTOUTPUT$\n\nHost description: $_HOSTDESC$\nHost Impact: $_HOSTIMPACT$" | /usr/bin/mail -s "Host $HOSTSTATE$ alert for $HOSTNAME$" $CONTACTEMAIL$
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/commands/detailled-service-by-email.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/commands/detailled-service-by-email.cfg
@@ -1,0 +1,7 @@
+
+## Notify Service by Email with detailled informations
+# Service have appropriate macros. Look at unix-fs pack to get an example
+define command {
+    command_name    detailled-service-by-email
+    command_line    /usr/bin/printf "%b" "Alignak Notification\n\nNotification Type: $NOTIFICATIONTYPE$\n\nService: $SERVICEDESC$\nHost: $HOSTALIAS$\nAddress: $HOSTADDRESS$\nState: $SERVICESTATE$\n\nDate/Time: $DATE$ at $TIME$\nService Output : $SERVICEOUTPUT$\n\nService Description: $_SERVICEDETAILLEDESC$\nService Impact: $_SERVICEIMPACT$\nFix actions: $_SERVICEFIXACTIONS$" | /usr/bin/mail -s "$SERVICESTATE$ on Host : $HOSTALIAS$/Service : $SERVICEDESC$" $CONTACTEMAIL$
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/commands/notify-host-by-email.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/commands/notify-host-by-email.cfg
@@ -1,0 +1,5 @@
+## Notify Host by Email
+define command {
+    command_name    notify-host-by-email
+    command_line    /usr/bin/printf "%b" "Alignak Notification\n\nType:$NOTIFICATIONTYPE$\nHost: $HOSTNAME$\nState: $HOSTSTATE$\nAddress: $HOSTADDRESS$\nInfo: $HOSTOUTPUT$\nDate/Time: $DATE$ $TIME$\n" | /usr/bin/mail -s "Host $HOSTSTATE$ alert for $HOSTNAME$" $CONTACTEMAIL$
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/commands/notify-service-by-email.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/commands/notify-service-by-email.cfg
@@ -1,0 +1,6 @@
+## Notify Service by Email
+define command {
+    command_name    notify-service-by-email
+    command_line    /usr/bin/printf "%b" "Alignak Notification\n\nNotification Type: $NOTIFICATIONTYPE$\n\nService: $SERVICEDESC$\nHost: $HOSTNAME$\nAddress: $HOSTADDRESS$\nState: $SERVICESTATE$\n\nDate/Time: $DATE$ $TIME$\nAdditional Info : $SERVICEOUTPUT$\n" | /usr/bin/mail -s "** $NOTIFICATIONTYPE$ alert - $HOSTNAME$/$SERVICEDESC$ is $SERVICESTATE$ **" $CONTACTEMAIL$
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/contactgroups/admins.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/contactgroups/admins.cfg
@@ -1,0 +1,6 @@
+define contactgroup{
+    contactgroup_name   admins
+    alias               admins
+    members             admin
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/contactgroups/users.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/contactgroups/users.cfg
@@ -1,0 +1,5 @@
+define contactgroup{
+    contactgroup_name   users
+    alias               users
+    members             admin
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/contacts/admin.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/contacts/admin.cfg
@@ -1,0 +1,13 @@
+# This is a default admin
+# CHANGE ITS PASSWORD!
+
+define contact{
+    use             generic-contact
+    contact_name    admin
+    email           alignak@localhost
+    pager           0600000000   ; contact phone number
+    password        admin
+    is_admin        1
+    expert	    1
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/contacts/guest.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/contacts/guest.cfg
@@ -1,0 +1,11 @@
+
+# This is a default guest user
+# CHANGE ITS PASSWORD or remove it
+define contact{
+    use                 generic-contact
+    contact_name        guest
+    email               guest@localhost
+    password            guest
+    can_submit_commands 0
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/dependencies/sample.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/dependencies/sample.cfg
@@ -1,0 +1,22 @@
+# Dependencies
+
+# This is the HARD way for define dependencies. Please look at the
+# service_dependencies property for the services instead!
+
+#define servicedependency {
+#       host_name                           dc01
+#       service_description                 ActiveDirectory
+#       dependent_host_name                 dc07
+#       dependent_service_description       ActiveDirectory
+#       execution_failure_criteria          o
+#       notification_failure_criteria       w,u
+#       dependency_period                   24x7
+#       }
+
+#define hostdependency{
+#       host_name                           dc01
+#       dependent_host_name                 localhost
+#       execution_failure_criteria          o
+#       notification_failure_criteria       u
+#       dependency_period                   24x7
+#       }

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/escalations/sample.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/escalations/sample.cfg
@@ -1,0 +1,17 @@
+
+
+# Define escalation the OLD school way.
+# Better use the simple "escalation" way! (in alignak-specific.cfg)
+
+#define serviceescalation{
+#       host_name               localhost
+#       hostgroup_name          windows-servers
+#       service_description     Root Partition
+#       contacts                GNULinux_Administrator
+#       contact_groups          admins
+#       first_notification      2
+#       last_notification       5
+#       notification_interval   1
+#       escalation_period       24x7
+#       escalation_options      w,u,c,r
+#       }

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/hostgroups/linux.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/hostgroups/linux.cfg
@@ -1,0 +1,5 @@
+define hostgroup{
+   hostgroup_name  linux   ; The name of the hostgroup
+   alias           Linux Servers   ; Long name of the group
+   #members
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/hosts/localhost.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/hosts/localhost.cfg
@@ -1,0 +1,28 @@
+define host{
+    use                     linux-snmp
+    contact_groups          admins
+    host_name               localhost
+    alias                   Web UI
+    display_name            Alignak Web UI
+    address                 127.0.0.1
+
+    hostgroups              monitoring_servers
+
+    # Web UI host importance
+    # Business impact (from 0 to 5)
+    business_impact          4
+
+    # Web UI map position
+    # GPS coordinates
+    _LOC_LAT                 48.858561
+    _LOC_LNG                 2.294449
+
+    # Web UI notes, actions, ...
+    notes                    simple note
+    notes                    Label::note with a label
+    notes                    KB1023,,tag::<strong>Lorem ipsum dolor sit amet</strong>, consectetur adipiscing elit. Proin et leo gravida, lobortis nunc nec, imperdiet odio. Vivamus quam velit, scelerisque nec egestas et, semper ut massa. Vestibulum id tincidunt lacus. Ut in arcu at ex egestas vestibulum eu non sapien. Nulla facilisi. Aliquam non blandit tellus, non luctus tortor. Mauris tortor libero, egestas quis rhoncus in, sollicitudin et tortor.|note simple|Tag::tagged note ...
+
+    notes_url                http://www.my-KB.fr?host=$HOSTADDRESS$|http://www.my-KB.fr?host=$HOSTNAME$
+
+    action_url               On a map,,globe::<strong>Viw it on a map</strong>,,https://www.google.fr/maps/place/Tour+Eiffel/@48.8583701,2.2939341,19z/data=!3m1!4b1!4m5!3m4!1s0x47e66e2964e34e2d:0x8ddca9ee380ef7e0!8m2!3d48.8583701!4d2.2944813
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/notificationways/detailled-email.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/notificationways/detailled-email.cfg
@@ -1,0 +1,12 @@
+# This is how emails are sent, 24x7 way.
+define notificationway{
+   notificationway_name            detailled-email
+   service_notification_period     24x7
+   host_notification_period        24x7
+   service_notification_options    c,w,r
+   host_notification_options       d,u,r,f,s
+   service_notification_commands   detailled-service-by-email ; send service notifications via email
+   host_notification_commands      detailled-host-by-email    ; send host notifications via email
+   min_business_impact             1
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/notificationways/email.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/notificationways/email.cfg
@@ -1,0 +1,11 @@
+# This is how emails are sent, 24x7 way.
+define notificationway{
+       notificationway_name            email
+       service_notification_period     24x7
+       host_notification_period        24x7
+       service_notification_options    c,w,r
+       host_notification_options       d,u,r,f,s
+       service_notification_commands   notify-service-by-email ; send service notifications via email
+       host_notification_commands      notify-host-by-email    ; send host notifications via email
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/realms/all.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/realms/all.cfg
@@ -1,0 +1,6 @@
+# Very advanced feature for multisite management.
+# Read the docs VERY CAREFULLY before changing these settings :)
+define realm {
+    realm_name  All
+    default     1
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/servicegroups/sample.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/servicegroups/sample.cfg
@@ -1,0 +1,15 @@
+
+# Service groups are less important than hosts group, but can be useful
+
+#define servicegroup{
+#   servicegroup_name   LocalServices
+#   alias               Local service
+#   members             localhost,Root Partition
+#   }
+
+#define servicegroup{
+#   servicegroup_name   WebService
+#   alias               All http service
+#   members             srv-web-1,Http
+#   }
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/services/services.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/services/services.cfg
@@ -1,0 +1,2 @@
+## In this directory you can put all your specific service
+# definitions

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/timeperiods/24x7.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/timeperiods/24x7.cfg
@@ -1,0 +1,12 @@
+define timeperiod{
+	timeperiod_name			24x7
+	alias				Always
+	sunday				00:00-24:00
+	monday				00:00-24:00
+	tuesday				00:00-24:00
+	wednesday			00:00-24:00
+	thursday			00:00-24:00
+	friday				00:00-24:00
+	saturday			00:00-24:00
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/timeperiods/none.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/timeperiods/none.cfg
@@ -1,0 +1,5 @@
+# 'none' timeperiod definition
+define timeperiod{
+	timeperiod_name	none
+	alias		No Time Is A Good Time
+	}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/timeperiods/us-holidays.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/timeperiods/us-holidays.cfg
@@ -1,0 +1,16 @@
+# Some U.S. holidays
+# Note: The timeranges for each holiday are meant to *exclude* the holidays from being
+# treated as a valid time for notifications, etc.  You probably don't want your pager
+# going off on New Year's.  Although you're employer might... :-)
+define timeperiod{
+	name			us-holidays
+        timeperiod_name         us-holidays
+        alias                   U.S. Holidays
+
+        january 1               00:00-00:00     ; New Years
+        monday -1 may           00:00-00:00     ; Memorial Day (last Monday in May)
+        july 4                  00:00-00:00     ; Independence Day
+        monday 1 september      00:00-00:00     ; Labor Day (first Monday in September)
+        thursday -1 november    00:00-00:00     ; Thanksgiving (last Thursday in November)
+        december 25             00:00-00:00     ; Christmas
+        }

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/timeperiods/workhours.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/objects/timeperiods/workhours.cfg
@@ -1,0 +1,10 @@
+# 'workhours' timeperiod definition
+define timeperiod{
+	timeperiod_name	workhours
+	alias		Normal Work Hours
+	monday		09:00-17:00
+	tuesday		09:00-17:00
+	wednesday	09:00-17:00
+	thursday	09:00-17:00
+	friday		09:00-17:00
+	}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/_my_passive_hosts_pack/groups.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/_my_passive_hosts_pack/groups.cfg
@@ -1,0 +1,12 @@
+# NSCA passively monitored host
+define hostgroup {
+    hostgroup_name                      north-hosts
+    alias                               North hosts
+}
+
+
+# NSCA passively monitored service
+define servicegroup {
+    servicegroup_name                   north-services
+    alias                               North hosts services
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/_my_passive_hosts_pack/services.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/_my_passive_hosts_pack/services.cfg
@@ -1,0 +1,239 @@
+# ============================================================
+# NSCA checks
+# ============================================================
+# ------------------------------------------------------------
+# Host software - main host application
+# ------------------------------------------------------------
+define service {
+    service_description         Application
+    alias                       Main host application
+    use                         north-service, 4hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 Application
+}
+
+# Services dependencies
+define servicedependency{
+    hostgroup_name	                    north-hosts
+    service_description                 Application
+    dependent_service_description       Session, Monitoring
+    execution_failure_criteria          o
+    notification_failure_criteria       w
+    dependency_period                   24x7
+
+    ; explode_hostgroup                   1
+}
+
+
+# ------------------------------------------------------------
+# Host software
+# ------------------------------------------------------------
+define service {
+    service_description         Session
+    alias                       Session
+    use                         north-service, 4hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_software
+}
+define service {
+    service_description         Monitoring
+    alias                       Monitoring
+    use                         north-service, 4hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_software
+}
+define service {
+    service_description         skPrinting_A
+    alias                       Impression
+    use                         north-service, 4hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_software
+
+    service_dependencies        ,dev_ReceiptPrinter
+}
+define service {
+    service_description         skTagReading_A
+    alias                       Lecture de codes à barres
+    use                         north-service, 4hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_software
+
+    service_dependencies        ,dev_BarcodeReader
+}
+define service {
+    service_description         skTagReading_B
+    alias                       Lecture de cartes sans contact
+    use                         north-service, 4hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_software
+
+    service_dependencies        ,dev_ContactlessReader
+}
+define service {
+    service_description         skPayment
+    alias                       Paiement CB
+    use                         north-service, 4hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_software
+
+    service_dependencies        ,dev_CBPayment
+}
+
+# ------------------------------------------------------------
+# Kiosk hardware
+# dev_TouchUI
+# dev_DisplayUI
+# dev_SoundUI
+# dev_BluetoothReader
+# dev_Network (LAN, WAN) ?
+# dev_CBPayment
+# dev_ReceiptPrinter
+# dev_BarcodeReader
+# dev_ContactlessReader
+# ------------------------------------------------------------
+define service {
+    service_description         dev_DisplayUI
+    alias                       Display
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+define service {
+    service_description         dev_SoundUI
+    alias                       Sound
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+define service {
+    service_description         dev_TouchUI
+    alias                       Touch device
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+define service {
+    service_description         dev_Network
+    alias                       Network
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+define service {
+    service_description         dev_BluetoothReader
+    alias                       Bluetooth
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+define service {
+    service_description         dev_ContactlessReader
+    alias                       Contactless card reader
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+define service {
+    service_description         dev_BarcodeReader
+    alias                       Barcode reader
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+define service {
+    service_description         dev_ReceiptPrinter
+    alias                       Receipt printer
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+define service {
+    service_description         dev_CBPayment
+    alias                       Bank card payment
+    use                         north-service, 12hours-freshness
+    register                    0
+    host_name                   north-host
+
+    aggregation                 host_hardware
+}
+
+# ------------------------------------------------------------
+# Windows PC hardware and services
+# ------------------------------------------------------------
+define service {
+    service_description         nsca_uptime
+    alias                       Uptime
+    use                         north-service
+    register                    0
+    host_name                   north-host
+
+    aggregation                 system
+}
+define service {
+    service_description         nsca_cpu
+    alias                       CPU
+    use                         north-service
+    register                    0
+    host_name                   north-host
+
+    aggregation                 system
+}
+define service {
+    service_description         nsca_memory
+    alias                       Memory
+    use                         north-service
+    register                    0
+    host_name                   north-host
+
+    aggregation                 system
+}
+define service {
+    service_description         nsca_disk
+    alias                       Disk
+    use                         north-service
+    register                    0
+    host_name                   north-host
+
+    aggregation                 system
+}
+
+define service {
+    service_description         nsca_services
+    alias                       Windows services (nsca)
+    use                         north-service
+    register                    0
+    host_name                   north-host
+
+    aggregation                 software
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/_my_passive_hosts_pack/templates.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/_my_passive_hosts_pack/templates.cfg
@@ -1,0 +1,38 @@
+# NSCA passively monitored host
+define host {
+    name						        north-host
+    use            				        windows-nsca-host
+    register       				        0
+
+    hostgroups                          north-hosts
+
+    # Check period
+    check_period                        north_hours
+
+    # Notification part
+    notifications_enabled		        1
+    notification_period                 north_hours
+
+    ; contacts		                    north
+    contact_groups		                north
+
+    # Realm
+    realm                               North
+}
+
+
+# NSCA passively monitored service
+define service {
+    name								north-service
+    use 								windows-nsca-service
+    register							0
+
+    servicegroups                       north-services
+
+    # Check period
+    check_period                        north_hours
+
+    # Notification part
+    notifications_enabled		        1
+    notification_period                 north_hours
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/_my_passive_hosts_pack/timeperiods.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/_my_passive_hosts_pack/timeperiods.cfg
@@ -1,0 +1,12 @@
+# 'kiosks_hours' timeperiod definition
+define timeperiod{
+    timeperiod_name     north_hours
+    alias               North hours
+
+    monday	        08:00-20:00
+    tuesday	        08:00-20:00
+    wednesday	        08:00-20:00
+    thursday	        08:00-20:00
+    friday	        08:00-20:00
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/monitoring/commands.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/monitoring/commands.cfg
@@ -1,0 +1,64 @@
+# Check host is alive
+define command {
+    command_name    check_host_alive
+    command_line    $MONITORING_PLUGINS_DIR$/check_ping -H $HOSTADDRESS$ -w 1000,100% -c 3000,100% -p 1 -t 10 -4
+}
+# Unlike check_ping, check_icmp allows for checking multiple hosts at once; the behaviour
+# is more configurable; and it generates performance data output.  But the main difference
+# is that check_ping executes the system's ping(1) command and parses its output while
+# check_icmp talks ICMP itself. This usually means that check_icmp must be installed
+# setuid root, but also that its performance is much better.
+define command {
+    command_name    check_host_alive_icmp
+    command_line    $MONITORING_PLUGINS_DIR$/check_icmp -H $HOSTADDRESS$ -w 200,40% -c 500,80%
+}
+
+# DNS check
+define command {
+    command_name    check_dns
+    command_line    $MONITORING_PLUGINS_DIR$/check_dns -H $_HOSTDNSHOSTNAME$ -a $_HOSTDNSEXPECTEDRESULT$ -s $HOSTADDRESS$
+}
+
+# SSH connection check
+define command {
+    command_name    check_ssh
+    command_line    $MONITORING_PLUGINS_DIR$/check_ssh -p $_HOSTSSHPORT$ $HOSTADDRESS$
+}
+
+# FTP check
+define command {
+    command_name    check_ftp
+    command_line    $MONITORING_PLUGINS_DIR$/check_ftp -H $HOSTADDRESS$
+}
+
+# Simple web check
+define command {
+    command_name    check_http
+    command_line    $MONITORING_PLUGINS_DIR$/check_http -H $_HOSTCHECK_HTTP_DOMAIN_NAME$ -u $_HOSTCHECK_HTTP_URI$ -p $_HOSTCHECK_HTTP_PORT$ --authorization=$_HOSTCHECK_HTTP_AUTH$
+}
+
+# And with SSL
+define command {
+    command_name    check_https
+    command_line    $MONITORING_PLUGINS_DIR$/check_http -H $_HOSTCHECK_HTTPS_DOMAIN_NAME$ -S --sni -u $_HOSTCHECK_HTTPS_URI$ -p $_HOSTCHECK_HTTPS_PORT$ --authorization=$_HOSTCHECK_HTTPS_AUTH$
+}
+
+
+# Look at a SSL certificate
+define command {
+    command_name    check_https_certificate
+    command_line    $MONITORING_PLUGINS_DIR$/check_http -H $_HOSTCHECK_HTTPS_DOMAIN_NAME$ -C $_HOSTCHECK_HTTPS_MINIMUM_DAYS$ --sni -p $_HOSTCHECK_HTTPS_PORT$ --authorization=$_HOSTCHECK_HTTPS_AUTH$
+}
+
+# Look at a Dhcp server
+# Beware: the check_dhcp should be SETUID (chmod u+s /usr/lib/nagios/plugins/check_dhcp)
+define command {
+    command_name    check_dhcp
+    command_line    $MONITORING_PLUGINS_DIR$/check_dhcp -s $HOSTADDRESS$
+}
+
+# Check if the rsync server is up and listening
+define command {
+    command_name    check_rsync
+    command_line    $MONITORING_PLUGINS_DIR$/check_rsync -H $HOSTADDRESS$ -p $_HOSTCHECK_RSYNC_PORT$
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/monitoring/services.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/monitoring/services.cfg
@@ -1,0 +1,87 @@
+# DNS
+define service{
+    service_description     Dns
+    use                     generic-service
+    register                0
+    host_name	            dns
+    check_command           check_dns
+
+   _DETAILLEDESC            Detect if DNS matches the expected IP address
+    _IMPACT                 High: name resolution is not routed to this machine
+    _FIXACTIONS             Check your DNS registrar
+}
+# SSH
+define service{
+    service_description     Ssh
+    use                     generic-service
+    register                0
+    host_name               ssh
+    check_command           check_ssh
+
+    _DETAILLEDESC           Check that open ssh port
+    _IMPACT                 Low: No ssh connexions possible
+    _FIXACTIONS             Start ssh service.
+}
+# FTP
+define service{
+    service_description     Ftp
+    use                     generic-service
+    register                0
+    host_name	            ftp
+    check_command           check_ftp
+
+    _DETAILLEDESC           Check that the host listens on FTP port
+    _IMPACT                 Low: No ftp transactions possible
+    _FIXACTIONS             Start ftp service.
+}
+
+# HTTP/HTTPS
+define service{
+    service_description     Http
+    use                     generic-service
+    register                0
+    host_name	            http
+    check_command           check_http
+}
+
+define service{
+    service_description     HttpsCertificate
+    use            	        generic-service
+    register       	        0
+    host_name	  	        https
+    check_command  	        check_https_certificate
+}
+
+define service{
+    service_description     Https
+    use                     generic-service
+    register                0
+    host_name	            https
+    check_command           check_https
+}
+
+# DHCP server
+define service{
+    service_description     Dhcp
+    use                     generic-service
+    register                0
+    host_name	            dhcp
+    check_command           check_dhcp
+
+    _DETAILLEDESC           Check that the host DHCP server is running
+    _IMPACT                 Medium: No DHCP lease available
+    _FIXACTIONS             Start dhcp service.
+}
+
+# Rsync server
+define service{
+    service_description     Rsync
+    use                     generic-service
+    register                0
+    host_name               rsync
+    check_command           check_rsync
+
+    _DETAILLEDESC           Check that the host rsync server is running
+    _IMPACT                 Medium: No rsync backup available
+    _FIXACTIONS             Start sync service.
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/monitoring/templates.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/monitoring/templates.cfg
@@ -1,0 +1,71 @@
+# Templates for hosts
+# Basic template to check host is alive
+define host{
+    name                monitored-host
+    use                 generic-host
+    register            0
+
+    check_command       check_host_alive
+}
+
+# DNS
+define host{
+    name                dns
+    use                 monitored-host
+    register            0
+
+    _DNSHOSTNAME                $HOSTNAME$
+    _DNSEXPECTEDRESULT          $HOSTADDRESS$
+}
+
+# SSH
+define host{
+    name                ssh
+    register            0
+
+    _SSHPORT            22
+}
+
+# FTP
+define host{
+    name                ftp
+    register            0
+}
+
+# HTTP/HTTPS
+define host{
+    name                http
+    use                 monitored-host
+    register            0
+
+    _CHECK_HTTP_DOMAIN_NAME     $HOSTADDRESS$
+    _CHECK_HTTP_PORT            80
+    _CHECK_HTTP_URI             /
+    _CHECK_HTTP_AUTH            #login:password
+}
+define host{
+    name                https
+    use                 monitored-host
+    register            0
+
+    _CHECK_HTTPS_DOMAIN_NAME    $HOSTADDRESS$
+    _CHECK_HTTPS_PORT           443
+    _CHECK_HTTPS_URI            /
+    _CHECK_HTTPS_AUTH           #login:password
+    _CHECK_HTTPS_MINIMUM_DAYS   30
+}
+
+# DHCP server
+define host{
+    name                dhcp
+    register            0
+}
+
+# rsync
+define host{
+    name                rsync
+    use                 monitored-host
+    register            0
+
+    _CHECK_RSYNC_PORT           873
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/mysql/commands.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/mysql/commands.cfg
@@ -1,0 +1,113 @@
+###########################################################
+# Commands definition
+###########################################################
+# Distant mysql check
+define command {
+    command_name    check_mysql_connection
+    command_line    $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode connection-time --warning $_HOSTCONNECTIONTIME_WARN$ --critical $_HOSTCONNECTIONTIME_CRIT$
+}
+
+define command {
+    command_name    check_mysql_querycache_hitrate
+    command_line    $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode querycache-hitrate --warning $_HOSTQUERYCACHEHITRATE_WARN$ --critical $_HOSTQUERYCACHEHITRATE_CRIT$
+}
+
+define command {
+    command_name     check_mysql_uptime
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode uptime --warning $_HOSTUPTIME_WARN$ --critical $_HOSTUPTIME_CRIT$
+}
+
+define command {
+    command_name     check_mysql_threads_connected
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode threads-connected --warning $_HOSTTHREADSCONNECTED_WARN$ --critical $_HOSTTHREADSCONNECTED_CRIT$
+}
+
+define command {
+    command_name     check_mysql_qcache_hitrate
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode qcache-hitrate --warning $_HOSTQCACHEHITRATE_WARN$ --critical $_HOSTQCACHEHITRATE_CRIT$
+}
+
+define command {
+    command_name     check_mysql_qcache_lowmem_prunes
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode qcache-lowmem-prunes --warning $_HOSTQCACHELOWMEMPRUNES_WARN$ --critical $_HOSTQCACHELOWMEMPRUNES_CRIT$
+}
+
+define command {
+    command_name     check_mysql_keycache_hitrate
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode keycache-hitrate --warning $_HOSTKEYCACHEHITRATE_WARN$ --critical $_HOSTKEYCACHEHITRATE_CRIT$
+}
+
+define command {
+    command_name     check_mysql_bufferpool_hitrate
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode bufferpool-hitrate --warning $_HOSTBUFFERPOOLHITRATE_WARN$ --critical $_HOSTBUFFERPOOLHITRATE_CRIT$
+}
+
+define command {
+    command_name     check_mysql_bufferpool_wait_free
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode bufferpool-wait-free --warning $_HOSTBUFFERPOOLWAITFREE_WARN$ --critical $_HOSTBUFFERPOOLWAITFREE_CRIT$
+}
+
+define command {
+    command_name     check_mysql_log_waits
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode log-waits --warning $_HOSTLOGWAITS_WARN$ --critical $_HOSTLOGWAITS_CRIT$
+}
+
+define command {
+    command_name     check_mysql_tablecache_hitrate
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode tablecache-hitrate --warning $_HOSTTABLECACHEHITRATE_WARN$ --critical $_HOSTTABLECACHEHITRATE_CRIT$
+}
+
+define command {
+    command_name     check_mysql_table_lock_contention
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode table-lock-contention --warning $_HOSTTABLELOCKCONTENTION_WARN$ --critical $_HOSTTABLELOCKCONTENTION_CRIT$
+}
+
+define command {
+    command_name     check_mysql_index_usage
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode index-usage --warning $_HOSTINDEXUSAGE_WARN$ --critical $_HOSTINDEXUSAGE_CRIT$
+}
+
+define command {
+    command_name     check_mysql_tmp_disk_tables
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode tmp-disk-tables --warning $_HOSTTMPDISKTABLES_WARN$ --critical $_HOSTTMPDISKTABLES_CRIT$
+}
+
+define command {
+    command_name     check_mysql_slow_queries
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode slow-queries --warning $_HOSTSLOWQUERIES_WARN$ --critical $_HOSTSLOWQUERIES_CRIT$
+}
+
+define command {
+    command_name     check_mysql_long_running_procs
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode long-running-procs --warning $_HOSTLONGRUNNINGPROCS_WARN$ --critical $_HOSTLONGRUNNINGPROCS_CRIT$
+}
+
+define command {
+    command_name     check_mysql_slave_lag
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode slave-lag --warning $_HOSTSLAVELAG_WARN$ --critical $_HOSTSLAVELAG_CRIT$
+}
+
+define command {
+    command_name     check_mysql_slave_io_running
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode slave-io-running
+}
+
+define command {
+    command_name     check_mysql_slave_sql_running
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode slave-sql-running
+}
+
+define command {
+    command_name     check_mysql_open_files
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode open-files --warning $_HOSTOPENFILES_WARN$ --critical $_HOSTOPENFILES_CRIT$
+}
+
+define command {
+    command_name     check_mysql_cluster_ndbd_running
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode cluster-ndbd-running
+}
+
+define command {
+    command_name     check_mysql_threadcache_hitrate
+    command_line     $PLUGINSDIR$/check_mysql_health --hostname $HOSTADDRESS$ --username $_HOSTMYSQLUSER$ --password $_HOSTMYSQLPASSWORD$ --mode threadcache-hitrate --warning $_HOSTTHREADCACHEHITRATE_WARN$ --critical $_HOSTTHREADCACHEHITRATE_CRIT$
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/mysql/groups.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/mysql/groups.cfg
@@ -1,0 +1,10 @@
+# Host and service groups
+define hostgroup {
+    hostgroup_name      mysql
+    alias               Mysql database hosts
+}
+
+define servicegroup {
+    servicegroup_name   mysql
+    alias               Mysql database services
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/mysql/services.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/mysql/services.cfg
@@ -1,0 +1,218 @@
+define service{
+   service_description      Mysql-connection
+   use                      mysql-service
+   register                 0
+   host_name	            mysql
+
+   check_command            check_mysql_connection
+}
+
+define service{
+    service_description     Mysql-restart
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_uptime
+    service_dependencies    ,Mysql-connection
+}
+
+define service{
+    service_description     Mysql-bufferpool-wait-free
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_bufferpool_wait_free
+
+    service_dependencies    ,Mysql-connection
+    aggregation		        /mysql/innodb
+}
+
+define service{
+    service_description     Mysql-index-usage
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_index_usage
+
+    service_dependencies    ,Mysql-connection
+}
+define service{
+    service_description     Mysql-log-waits
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_log_waits
+    service_dependencies    ,Mysql-connection
+    aggregation		        /mysql/innodb
+}
+define service{
+    service_description     Mysql-long-running-procs
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_long_running_procs
+    service_dependencies    ,Mysql-connection
+}
+define service{
+    service_description     Mysql-open-files
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_open_files
+
+    service_dependencies    ,Mysql-connection
+    aggregation		        /mysql/limits
+}
+define service{
+    service_description     Mysql-slow-queries
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_slow_queries
+
+    service_dependencies    ,Mysql-connection
+}
+define service{
+    service_description     Mysql-table-lock-contention
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_table_lock_contention
+
+    service_dependencies    ,Mysql-connection
+}
+
+# Cache management
+define service{
+    service_description     Mysql-qcache-hitrate
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_qcache_hitrate
+
+    service_dependencies    ,Mysql-connection
+    aggregation	            mysql/cachehit
+}
+define service{
+    service_description     Mysql-qcache-lowmem-prunes
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_qcache_lowmem_prunes
+
+    service_dependencies    ,Mysql-connection
+    aggregation	  		    mysql/cachehit
+}
+define service{
+    service_description     Mysql-keycache-hitrate
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_keycache_hitrate
+
+    service_dependencies    ,Mysql-connection
+    aggregation	            mysql/cachehit
+}
+define service{
+    service_description     Mysql-bufferpool-hitrate
+    use            		    mysql-service
+    register       		    0
+    host_name	 		    mysql
+
+    check_command  		    check_mysql_bufferpool_hitrate
+
+    service_dependencies    ,Mysql-connection
+    aggregation	  		    mysql/cachehit
+}
+define service{
+    service_description     Mysql-tablecache-hitrate
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_tablecache_hitrate
+
+    service_dependencies    ,Mysql-connection
+    aggregation	            mysql/cachehit
+}
+define service{
+    service_description     Mysql-threadcache-hitrate
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_threadcache_hitrate
+
+    service_dependencies    ,Mysql-connection
+    aggregation	            mysql/cachehit
+}
+
+define service{
+    service_description     Mysql-threads-connected
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_threads_connected
+
+    service_dependencies    ,Mysql-connection
+    aggregation		        /mysql/limits
+}
+
+define service{
+    service_description     Mysql-tmp-disk-tables
+    use                     mysql-service
+    register                0
+    host_name	            mysql
+
+    check_command           check_mysql_tmp_disk_tables
+
+    service_dependencies    ,Mysql-connection
+}
+
+# For a slave DB...
+define service{
+    service_description     Mysql-slave-lag
+    use                     generic-service
+    register                0
+    host_name	            mysql-slave
+
+    check_command           check_mysql_slave_lag
+}
+define service{
+    service_description     Mysql-slave-sql-running
+    use                     generic-service
+    register                0
+    host_name	            mysql-slave
+
+    check_command           check_mysql_slave_sql_running
+}
+define service{
+    service_description     Mysql-slave-io-running
+    use                     generic-service
+    register                0
+    host_name	            mysql-slave
+
+    check_command           check_mysql_slave_io_running
+}
+
+# For a Mysql cluster...
+define service{
+    service_description     Mysql-cluster-ndbd-running
+    use                     mysql-service
+    register                0
+    host_name	            mysql-cluster
+
+    check_command           check_mysql_cluster_ndbd_running
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/mysql/templates.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/mysql/templates.cfg
@@ -1,0 +1,80 @@
+# NSCA passively monitored host
+# DATABASES HOSTS
+define host{
+    name                            generic-mysql
+    register                        0
+
+    hostgroups                      mysql
+
+    _MYSQLUSER                      $MYSQLUSER$
+    _MYSQLPASSWORD                  $MYSQLPASSWORD$
+}
+
+define host{
+    name                            mysql
+    use                             generic-mysql
+    register                        0
+
+    # The plugin need a ":" sign when perfdata should be greater than the thresholds.
+    _UPTIME_WARN		            10:
+    _UPTIME_CRIT		             5:
+    _CONNECTIONTIME_WARN             1
+    _CONNECTIONTIME_CRIT             5
+    _QUERYCACHEHITRATE_WARN         90:
+    _QUERYCACHEHITRATE_CRIT         80:
+    _THREADSCONNECTED_WARN          10
+    _THREADSCONNECTED_CRIT          20
+    _QCACHEHITRATE_WARN             90:
+    _QCACHEHITRATE_CRIT             80:
+    _QCACHELOWMEMPRUNES_WARN         1
+    _QCACHELOWMEMPRUNES_CRIT        10
+    _KEYCACHEHITRATE_WARN           99:
+    _KEYCACHEHITRATE_CRIT           95:
+    _BUFFERPOOLHITRATE_WARN         99:
+    _BUFFERPOOLHITRATE_CRIT         95:
+    _BUFFERPOOLWAITFREE_WARN         1
+    _BUFFERPOOLWAITFREE_CRIT        10
+    _LOGWAITS_WARN                   1
+    _LOGWAITS_CRIT                  10
+    _TABLECACHEHITRATE_WARN         99:
+    _TABLECACHEHITRATE_CRIT         95:
+    _TABLELOCKCONTENTION_WARN        1
+    _TABLELOCKCONTENTION_CRIT        2
+    _INDEXUSAGE_WARN                90:
+    _INDEXUSAGE_CRIT                80:
+    _TMPDISKTABLES_WARN             25
+    _TMPDISKTABLES_CRIT             50
+    _SLOWQUERIES_WARN               0.1
+    _SLOWQUERIES_CRIT                1
+    _LONGRUNNINGPROCS_WARN          10
+    _LONGRUNNINGPROCS_CRIT          20
+    _OPENFILES_WARN                 80
+    _OPENFILES_CRIT                 95
+    _THREADCACHEHITRATE_WARN        99:
+    _THREADCACHEHITRATE_CRIT        95:
+}
+
+define host{
+    name                            mysql-slave
+    use                             generic-mysql
+    register                        0
+
+    _SLAVELAG_WARN                  10
+    _SLAVELAG_CRIT                  20
+}
+
+define host{
+    name                            mysql-cluster
+    use                             generic-mysql
+    register                        0
+}
+
+define service{
+    name			                mysql-service
+    use				                generic-service
+    register                        0
+
+    aggregation		                mysql
+
+    servicegroups                   mysql
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/nrpe/commands.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/nrpe/commands.cfg
@@ -1,0 +1,28 @@
+# -----------------------------------------------------------------
+# Default NRPE commands
+# -----------------------------------------------------------------
+## Ask NRPE agent version
+## Requires that you have the NRPE daemon running on the remote host.
+# check_nrpe -H <host> [-n] [-u] [-p <port>] [-t <timeout>] [-c <command>] [-a <arglist...>]
+# -n: no SSL
+# -u: UNKNOWN state if timeout occurs instead of CRITICAL
+# -4: IPv4 only
+# -6: IPv6 only
+# -p: port
+# -t: timeout (seconds)
+define command {
+   command_name    check_nrpe_version
+   command_line    $NRPE_PLUGINS_DIR$/check_nrpe2 -H $HOSTADDRESS$ -t $_HOSTNRPE_TIMEOUT$ -u
+}
+
+## Ask NRPE agent, without any argument
+define command {
+   command_name    check_nrpe
+   command_line    $NRPE_PLUGINS_DIR$/check_nrpe2 -H $HOSTADDRESS$ -t $_HOSTNRPE_TIMEOUT$ -u -c $ARG1$
+}
+
+## Ask NRPE agent with arguments (passing arguments may be a security risk)
+define command {
+   command_name    check_nrpe_args
+   command_line    $NRPE_PLUGINS_DIR$/check_nrpe2 -H $HOSTADDRESS$ -t $_HOSTNRPE_TIMEOUT$ -u -c $ARG1$ -a $ARG2$ $ARG3$ $ARG4$ $ARG5$ $ARG6$ $ARG7$ $ARG8$ $ARG9$
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/nrpe/groups.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/nrpe/groups.cfg
@@ -1,0 +1,10 @@
+# Host and service groups
+define hostgroup {
+    hostgroup_name      nrpe
+    alias               NRPE checked hosts group
+}
+
+define servicegroup{
+    servicegroup_name   nrpe
+    alias               NRPE checked services
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/nrpe/services.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/nrpe/services.cfg
@@ -1,0 +1,91 @@
+# Default NRPE commands configured after fresh server install
+# --------------------------------------------------------------------------------------------
+# command[check_users]=/usr/lib/nagios/plugins/check_users -w 5 -c 10
+# command[check_load]=/usr/lib/nagios/plugins/check_load -w 15,10,5 -c 30,25,20
+# command[check_hda1]=/usr/lib/nagios/plugins/check_disk -w 20% -c 10% -p /dev/hda1
+# command[check_zombie_procs]=/usr/lib/nagios/plugins/check_procs -w 5 -c 10 -s Z
+# command[check_total_procs]=/usr/lib/nagios/plugins/check_procs -w 150 -c 200
+
+# Server information
+define service {
+    service_description     Nrpe-status
+    use                     linux-nrpe-service
+    register                0
+    host_name               linux-nrpe
+    check_command           check_nrpe_version
+
+    max_check_attempts      2
+}
+
+# Server health
+define service {
+    service_description     Disks
+    use                     linux-nrpe-service
+    register                0
+    host_name               linux-nrpe
+    check_command           check_nrpe!check_hda1
+
+    _DETAILLEDESC           Overall disks usage
+    _IMPACT                 Depends on disks, cause system instability
+    _FIXACTIONS             Clean the appropriate disks
+
+    aggregation             Health
+
+    service_dependencies    ,Nrpe-status
+}
+define service {
+    service_description     Load
+    use                     linux-nrpe-service
+    register                0
+    host_name               linux-nrpe
+    check_command           check_nrpe!check_load
+
+    _DETAILLEDESC           Detect abnormal CPU usage
+    _IMPACT                 Slow down applications hosted by the system
+    _FIXACTIONS             If recurrent situation then make performance audit
+
+    aggregation             Health
+
+    service_dependencies    ,Nrpe-status
+}
+define service {
+    service_description     Users
+    use                     linux-nrpe-service
+    register                0
+    host_name               linux-nrpe
+    check_command           check_nrpe!check_users
+
+    service_dependencies    ,Nrpe-status
+}
+
+define service {
+    service_description     Procs
+    use                     linux-nrpe-service
+    register                0
+    host_name               linux-nrpe
+    check_command           check_nrpe!check_total_procs
+
+    _DETAILLEDESC           Detect abnormal running processus count
+    _IMPACT                 Slow down applications hosted by the system
+    _FIXACTIONS             Try to decrease the running processus number
+
+    aggregation             Health
+
+    service_dependencies    ,Nrpe-status
+}
+
+define service {
+    service_description     Zombies
+    use                     linux-nrpe-service
+    register                0
+    host_name               linux-nrpe
+    check_command           check_nrpe!check_zombie_procs
+
+    _DETAILLEDESC           Detect abnormal dead processus
+    _IMPACT                 Slow down applications hosted by the system
+    _FIXACTIONS             Kill the dead zombie processus
+
+    aggregation             Health
+
+    service_dependencies    ,Nrpe-status
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/nrpe/templates.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/nrpe/templates.cfg
@@ -1,0 +1,24 @@
+# Host and service templates
+define host {
+    name                linux-nrpe
+    use                 generic-host
+    register            0
+
+    check_command       check_nrpe_version
+
+    hostgroups          nrpe
+
+    ; Default timeout
+    _NRPE_TIMEOUT            10
+}
+
+define service {
+    name                linux-nrpe-service
+    use                 generic-service
+    register            0
+    aggregation         system
+
+    max_check_attempts  4
+
+    servicegroups       nrpe
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/readme.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/readme.cfg
@@ -1,0 +1,5 @@
+#
+# In this place you will find all the packs built and installed for Alignak
+#
+# You can freely adapt them to your own needs.
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/monitoring.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/monitoring.cfg
@@ -1,0 +1,4 @@
+
+#-- Monitoring plugins installation directory
+$MONITORING_PLUGINS_DIR$=/usr/local/libexec
+#--

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/mysql.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/mysql.cfg
@@ -1,0 +1,4 @@
+
+#-- MySQL default credentials
+$MYSQLUSER$=root
+$MYSQLPASSWORD$=root

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/nrpe.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/nrpe.cfg
@@ -1,0 +1,5 @@
+
+#-- NRPE check plugin installation directory
+# Default is to use the Alignak plugins directory
+$NRPE_PLUGINS_DIR$=/usr/local/libexec/nagios/
+#--

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/readme.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/readme.cfg
@@ -1,0 +1,3 @@
+#
+# In this place you will find the Alignak global macros defined by the installed packs
+#

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/snmp.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/snmp.cfg
@@ -1,0 +1,4 @@
+
+#-- Default SNMP community
+$SNMPCOMMUNITYREAD$=public
+#--

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/wmi.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/resource.d/wmi.cfg
@@ -1,0 +1,13 @@
+
+#-- WMI Plugin (check_wmi) configuration
+$WMI_INI_DIR$=$PLUGINSDIR$/check_wmi_plus.d
+
+
+#-- Active Directory for WMI
+# Replace MYDOMAIN with your domain name or . for local user account
+$DOMAIN$=MYDOMAIN
+# Replace MYUSER with the WMI authorized user (domain or local user account)
+$DOMAINUSERSHORT$=MYUSER
+$DOMAINUSER$=$DOMAIN$\\$DOMAINUSERSHORT$
+# Replace MYPASSWORD with the WMI authorized user password
+$DOMAINPASSWORD$=MYPASSWORD

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/snmp/commands.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/snmp/commands.cfg
@@ -1,0 +1,40 @@
+# -----------------------------------------------------------------
+#
+#   Linux SNMP standard check
+#
+# -----------------------------------------------------------------
+
+
+# Will check that host is alive
+define command {
+    command_name  check_snmp_alive
+    command_line  $PLUGINSDIR$/check_snmp_uptime.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -f -w
+}
+
+
+define command {
+    command_name  check_snmp_load
+    command_line  $PLUGINSDIR$/check_snmp_load.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -f -w $_HOSTLOAD_WARN$ -c $_HOSTLOAD_CRIT$ -T netsl -o $_HOSTSNMP_MSG_MAX_SIZE$
+}
+
+define command {
+    command_name  check_snmp_disks
+    command_line  $PLUGINSDIR$/check_snmp_storage.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -f -m $_HOSTSTORAGE_PATH$ -w $_HOSTSTORAGE_WARN$ -c $_HOSTSTORAGE_CRIT$ -S0,1 -o $_HOSTSNMP_MSG_MAX_SIZE$
+}
+
+define command {
+    command_name  check_snmp_cpu
+    command_line  $PLUGINSDIR$/check_snmp_load.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -f -w $_HOSTCPU_WARN$ -c $_HOSTCPU_CRIT$ -o $_HOSTSNMP_MSG_MAX_SIZE$
+}
+
+# Added -g flag since all linux system used are 64bits.
+#
+define command {
+    command_name  check_snmp_network_usage
+    command_line  $PLUGINSDIR$/check_snmp_network.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -n "$_HOSTNET_IFACES$" -g -2c -f -e -w $_HOSTNET_WARN$ -c $_HOSTNET_CRIT$ -q -k -y -M -B -m -P "$SERVICEPERFDATA$" -T "$LASTSERVICECHECK$"  -o $_HOSTSNMP_MSG_MAX_SIZE$
+}
+
+define command {
+    command_name  check_snmp_memory
+    command_line  $PLUGINSDIR$/check_snmp_mem.pl -H $HOSTADDRESS$ -C $_HOSTSNMPCOMMUNITY$ -w $_HOSTMEMORY_WARN$ -c $_HOSTMEMORY_CRIT$
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/snmp/groups.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/snmp/groups.cfg
@@ -1,0 +1,10 @@
+# Host and service groups
+define hostgroup {
+    hostgroup_name      snmp
+    alias               SNMP checked hosts group
+}
+
+define servicegroup{
+    servicegroup_name   snmp
+    alias               SNMP checked services
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/snmp/services.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/snmp/services.cfg
@@ -1,0 +1,66 @@
+# Server health
+define service {
+    service_description   Cpu
+    use                   linux-snmp-service
+    register              0
+    host_name             linux-snmp
+    check_command         check_snmp_cpu
+
+    _DETAILLEDESC         Detect abnormal CPU usage
+    _IMPACT               Slow down applications hosted by the system
+    _FIXACTIONS           If recurrent situation then make performance audit
+
+    aggregation          Health
+}
+define service {
+    service_description   Disks
+    use                   linux-snmp-service
+    register              0
+    host_name             linux-snmp
+    check_command         check_snmp_disks
+
+    _DETAILLEDESC         Overall disks usage
+    _IMPACT               Depends on disks, cause system instability
+    _FIXACTIONS           Clean the appropriate disks
+
+    aggregation          Health
+}
+define service {
+    service_description   Load
+    use                   linux-snmp-service
+    register              0
+    host_name             linux-snmp
+    check_command         check_snmp_load
+
+    _DETAILLEDESC         Detect abnormal CPU usage
+    _IMPACT               Slow down applications hosted by the system
+    _FIXACTIONS           If recurrent situation then make performance audit
+
+    aggregation          Health
+}
+define service {
+    service_description   Memory
+    use                   linux-snmp-service
+    register              0
+    host_name             linux-snmp
+    check_command         check_snmp_memory
+
+    _DETAILLEDESC         Check about memory and swap space usage. Too many use of swap space means lacks of memory or memory leaks.
+    _IMPACT               Average : More IO made and important slowed down applications performances.
+    _FIXACTIONS           Search memory processes consumers. Add more memory.
+
+    aggregation          Health
+}
+define service {
+    service_description   NetworkUsage
+    use                   linux-snmp-service
+    register              0
+    host_name             linux-snmp
+    check_command         check_snmp_network_usage
+
+    _DETAILLEDESC         Check bandwidth usage and network communications quality reporting errors and discarded packets.
+    _IMPACT               Average: Slowed down connectivity performance
+    _FIXACTIONS           Audit about network consumers processes and most likely wire quality and bad switches configuration.
+
+    aggregation          Health
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/snmp/templates.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/snmp/templates.cfg
@@ -1,0 +1,38 @@
+# Host and service templates
+define host {
+    name                linux-snmp
+    use                 generic-host
+    register            0
+
+    check_command       check_snmp_alive
+
+    hostgroups          linux-snmp
+
+    ; Default community is defined in resources.cfg
+    _SNMPCOMMUNITY      $SNMPCOMMUNITYREAD$
+    _SNMP_MSG_MAX_SIZE  65535
+
+    _LOAD_WARN          2,2,2
+    _LOAD_CRIT          3,3,3
+    _STORAGE_WARN       90
+    _STORAGE_CRIT       95
+    _CPU_WARN           80
+    _CPU_CRIT           90
+    _MEMORY_WARN        80,80
+    _MEMORY_CRIT        95,95
+    # Usual eth* interfaces
+    # Board embedded em* p*p* interfaces
+    # New predictable name: en* / wl*
+    _NET_IFACES         eth\d+|em\d+|p\d+p\d+|en\.+
+    _NET_WARN           90,90,0,0,0,0
+    _NET_CRIT           0,0,0,0,0,0
+}
+
+define service {
+    name                linux-snmp-service
+    use                 generic-service
+    register            0
+    aggregation         system
+
+    servicegroups       linux-snmp
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/windows-nsca/commands.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/windows-nsca/commands.cfg
@@ -1,0 +1,12 @@
+###########################################################
+# Commands definition
+###########################################################
+define command {
+	command_name    nsca_host_dead
+	command_line    _echo
+}
+
+define command {
+	command_name    nsca_service_dead
+	command_line    _echo
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/windows-nsca/groups.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/windows-nsca/groups.cfg
@@ -1,0 +1,10 @@
+# Host and service groups
+define hostgroup {
+    hostgroup_name      windows-nsca-hosts
+    alias               Windows NSCA passively monitored hosts
+}
+
+define servicegroup {
+    servicegroup_name   windows-nsca-services
+    alias               Windows NSCA passively monitored services
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/windows-nsca/services.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/windows-nsca/services.cfg
@@ -1,0 +1,53 @@
+
+# ============================================================
+# NSCA checks
+# ============================================================
+# ------------------------------------------------------------
+# Windows PC
+# ------------------------------------------------------------
+define service {
+    service_description         nsca_uptime
+    alias                       Uptime
+    use                         windows-nsca-service
+    register                    0
+    host_name                   windows-nsca-host
+
+	aggregation				    system
+}
+define service {
+    service_description         nsca_cpu
+    alias                       CPU
+    use                         windows-nsca-service
+    register                    0
+    host_name                   windows-nsca-host
+
+	aggregation				    system
+}
+define service {
+    service_description         nsca_memory
+    alias                       Memory
+    use                         windows-nsca-service
+    register                    0
+    host_name                   windows-nsca-host
+
+	aggregation				    system
+}
+define service {
+    service_description         nsca_disk
+    alias                       Disk
+    use                         windows-nsca-service
+    register                    0
+    host_name                   windows-nsca-host
+
+	aggregation				    system
+}
+
+define service {
+	service_description		    nsca_services
+	alias                       Windows services (nsca)
+	use 					    windows-nsca-service
+	register                    0
+    host_name                   windows-nsca-host
+
+	aggregation				    software
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/windows-nsca/templates.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/windows-nsca/templates.cfg
@@ -1,0 +1,74 @@
+# NSCA passively monitored host
+define host {
+    name						        windows-nsca-host
+    use            				        generic-host
+    register       				        0
+
+    hostgroups                          windows-nsca-hosts
+
+	# Checking part
+	check_command				        nsca_host_dead
+	max_check_attempts			        1
+
+	# No active checks, passive checks only
+	active_checks_enabled		        0
+	passive_checks_enabled		        1
+
+	# Checks must have been received within last 2 hours ...
+	check_freshness				        1
+	freshness_threshold			        1200
+}
+
+
+# NSCA passively monitored service
+define service {
+	name								windows-nsca-service
+	use 								generic-service
+	register							0
+
+    servicegroups                       windows-nsca-services
+
+	# No active checks, passive checks only
+	active_checks_enabled				0       ; Active service checks are disabled
+	passive_checks_enabled				1       ; Passive service checks are enabled/accepted
+
+	# Checks must have been received within last 20 minutes ...
+	check_freshness						1       ; Activate freshness check
+	freshness_threshold					1200    ; Freshness is 2 hours
+
+	# Dummy command ...
+	check_command           			nsca_service_dead
+}
+
+# One hour freshness period
+define service {
+	name								1hour-freshness
+	register							0
+
+	# Checks must have been received within last 4 hours ...
+	freshness_threshold					14400
+}
+# Four hours freshness period
+define service {
+	name								4hours-freshness
+	register							0
+
+	# Checks must have been received within last 4 hours ...
+	freshness_threshold					14400
+}
+# Twelve hours freshness period
+define service {
+	name								12hours-freshness
+	register							0
+
+	# Checks must have been received within last 12 hours ...
+	freshness_threshold					43200
+}
+# One day long freshness period
+define service {
+	name								1day-freshness
+	register							0
+
+	# Checks must have been received within last 12 hours ...
+	freshness_threshold					86400
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/wmi/commands.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/wmi/commands.cfg
@@ -1,0 +1,115 @@
+# All windows commands are using the check_wmi_plus.pl plugin. Install it with the shinken.sh script.
+# You will also need to update the _domainuser _domainpassword macros of your host if it's specific,
+# or the defaults values in the etc/shinken/resources.cfg file for global ones.
+
+
+# Will check that host is alive
+define command {
+   command_name	    check_wmi_alive
+   command_line	    $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkuptime
+}
+
+# Will check to get host OS information
+define command {
+   command_name	    check_wmi_info
+   command_line	    $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m info -s os -w 2yr
+}
+
+# Will check all windows disks. -o means the perfdata will be with E: and not names
+# and -3 is for printing bad states first in output
+define command {
+   command_name	    check_wmi_disks
+   command_line	    $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkdrivesize -a '.'  -w $_HOSTWINDOWS_DISK_WARN$ -c $_HOSTWINDOWS_DISK_CRIT$ -o 0 -3 1  --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+
+# Will look for the $ARG1$ (check_wmi_eventlogs!application for example) log for at least Severity Level "Warning", were
+# recorded in the last 1 hours
+define command {
+   command_name     check_wmi_eventlogs
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkeventlog -a $ARG1$ -o 2 -3 1  -w $_HOSTWINDOWS_EVENT_LOG_WARN$ -c $_HOSTWINDOWS_EVENT_LOG_CRIT$ --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+
+# Look for a recent reboot
+define command {
+   command_name     check_wmi_reboot
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkuptime -w '$_HOSTWINDOWS_REBOOT_WARN$' -c '$_HOSTWINDOWS_REBOOT_CRIT$' --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Look for the physical memory
+define command {
+   command_name     check_wmi_physical_memory
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkmem -w $_HOSTWINDOWS_MEM_WARN$ -c $_HOSTWINDOWS_MEM_CRIT$ --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# And look for swap
+define command {
+   command_name     check_wmi_swap
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkpage -a auto --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+
+# Look for overall CPU
+define command {
+   command_name     check_wmi_overall_cpu
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkcpu -w $_HOSTWINDOWS_ALL_CPU_WARN$ -c $_HOSTWINDOWS_ALL_CPU_CRIT$ --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# And for each CPU
+define command {
+   command_name     check_wmi_each_cpu
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkeachcpu -w $_HOSTWINDOWS_CPU_WARN$ -c $_HOSTWINDOWS_CPU_CRIT$ --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Somelike load average
+# Check 20times as quick as possible
+define command {
+   command_name     check_wmi_loadaverage
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkcpuq  -w $_HOSTWINDOWS_LOAD_WARN$ -c $_HOSTWINDOWS_LOAD_CRIT$ -a 20 -y 0 --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Check windows network interfaces with valid mac address
+define command {
+   command_name     check_wmi_network
+   # Append this to the command line if you have encoding problems:
+   # --extrawmicarg '--option=dos charset=latin1'
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checknetwork -w "_ReceiveBytesUtilisation=$_HOSTWINDOWS_NET_WARN$" -c "_ReceiveBytesUtilisation=$_HOSTWINDOWS_NET_CRIT$" -w "_SendBytesUtilisation=$_HOSTWINDOWS_NET_WARN$" -c "_SendBytesUtilisation=$_HOSTWINDOWS_NET_CRIT$" -a "^([0-9A-F]{2}[:-]){5}([0-9A-F]{2})$$" --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Auto services are started
+define command {
+   command_name     check_wmi_auto_services
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkservice -a Auto -o '$_HOSTWINDOWS_EXCLUDED_AUTO_SERVICES$' -w $_HOSTWINDOWS_AUTO_SERVICES_WARN$ -c $_HOSTWINDOWS_AUTO_SERVICES_CRIT$ --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Will warn for a >25% CPU process
+define command {
+   command_name     check_wmi_big_processes
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkproc -s cpuabove -a '%' -w $_HOSTWINDOWS_BIG_PROCESSES_WARN$ -exc _AvgCPU=@0:25 --nodataexit 0 --nodatastring "No processes with high CPU found" --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Will warn for a >25% CPU process that we give it the name
+# like check_wmi_big_process!firefox
+define command {
+   command_name     check_wmi_big_process
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkproc -s cpu -a '$ARG1$'  --nodatamode --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Look for disks I/Os
+define command {
+   command_name     check_wmi_disks_io
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkio -s logical -a '%' --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Look for too much inactive TS sessions. 0 or 1 is ok, 2 or more is warning
+define command {
+   command_name     check_wmi_inactive_ts_sessions
+   command_line     $PLUGINSDIR$/check_wmi_plus.pl -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSER$" -p "$_HOSTDOMAINPASSWORD$" -m checkts -s sessions -w 'InactiveSessions=0:9' --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}
+
+# Check a windows share
+define command {
+   command_name     check_wmi_share
+   command_line     $PLUGINSDIR$/check_disk_smb -H $HOSTADDRESS$ -u "$_HOSTDOMAINUSERSHORT$" -p "$_HOSTDOMAINPASSWORD$" -W '$_HOSTDOMAIN$' -s '$ARG1$' -w $_HOSTWINDOWS_SHARE_WARN$ -c $_HOSTWINDOWS_SHARE_CRIT$ --inidir=$PLUGINSDIR$/check_wmi_plus.d
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/wmi/groups.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/wmi/groups.cfg
@@ -1,0 +1,10 @@
+# Host and service groups
+define hostgroup {
+    hostgroup_name      wmi
+    alias               WMI checked hosts group
+}
+
+define servicegroup{
+    servicegroup_name   wmi
+    alias               WMI checked services
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/wmi/services.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/wmi/services.cfg
@@ -1,0 +1,214 @@
+# Server information
+define service{
+    service_description  Wmi-connection
+    use                  windows-wmi-service
+    register             0
+    host_name            windows-wmi
+    check_command        check_wmi_info
+
+    aggregation          Information
+}
+
+# Server health
+define service{
+    service_description     BigProcesses
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_big_processes
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     Cpu
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_overall_cpu
+
+    _DETAILLEDESC           Detect abnormal CPU usage
+    _IMPACT                 Slow down applications hosted by the system
+    _FIXACTIONS             If recurrent situation then make performance audit
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     EachCpu
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_each_cpu
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     Disks
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_disks
+
+    _DETAILLEDESC           Overall disks usage
+    _IMPACT                 Depends on disks, cause system instability
+    _FIXACTIONS             Clean the appropriate disks
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     DisksIO
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_disks_io
+
+    _DETAILLEDESC           I/O disks usage
+    _IMPACT                 Depends on disks, cause system instability
+    _FIXACTIONS             Clean the appropriate disks
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     LoadAverage
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_loadaverage
+
+    _DETAILLEDESC           Detect abnormal CPU usage
+    _IMPACT                 Slow down applications hosted by the system
+    _FIXACTIONS             If recurrent situation then make performance audit
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+define service {
+    service_description     Network Interface
+    use                     5min_long, windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_network
+
+    _DETAILLEDESC           Check bandwidth usage and network communications quality reporting errors and discarded packets.
+    _IMPACT                 Average: Slowed down connectivity performance
+    _FIXACTIONS             Audit about network consuming processes and most likely wire quality and bad switches configuration.
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     Memory
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_physical_memory
+
+    _DETAILLEDESC           Check about memory and swap space usage. Too many use of swap space means lacks of memory or memory leaks.
+    _IMPACT                 Average : More IO made and important slowed down applications performances.
+    _FIXACTIONS             Search memory consuming processes. Extend memory.
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     Reboot
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_reboot
+
+    aggregation             Health
+
+    service_dependencies    ,Wmi-connection
+}
+
+# Server OS
+define service{
+    service_description     Swap
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_swap
+
+    _DETAILLEDESC           Check about swap space usage. Too many use of swap space means lacks of memory or memory leaks.
+    _IMPACT                 Average : More IO made and important slowed down applications performances.
+    _FIXACTIONS             Search swapping processes. Extend memory.
+
+    aggregation             System
+}
+define service{
+    service_description     EventLogApplication
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_eventlogs!application
+
+    aggregation             System
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     EventLogSystem
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_eventlogs!system
+
+    aggregation             System
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     InactiveSessions
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_inactive_ts_sessions
+
+    _DETAILLEDESC           Check about inactive Terminal server session.
+    _IMPACT                 Average : session should be closed by the user when logging-out.
+    _FIXACTIONS             Change the session auto-close behavior.
+
+    aggregation             System
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     Services
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_auto_services
+
+    _DETAILLEDESC           Check about stopped auto-start services.
+    _IMPACT                 Average : auto-start services should be running.
+    _FIXACTIONS             Check why services are stopped. Add services to the exluded services list.
+
+    aggregation             System
+
+    service_dependencies    ,Wmi-connection
+}
+define service{
+    service_description     ShareSpace-$KEY$
+    use                     windows-wmi-service
+    register                0
+    host_name               windows-wmi
+    check_command           check_wmi_share!$KEY$
+    duplicate_foreach       _shares
+
+    aggregation             System
+
+    service_dependencies    ,Wmi-connection
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/wmi/templates.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/packs/wmi/templates.cfg
@@ -1,0 +1,55 @@
+# Windows template.
+define host{
+    name                            windows-wmi
+    use                             generic-host
+    register                        0
+
+    check_command                   check_wmi_alive
+
+    hostgroups                      wmi
+
+    # Macros. If not overloaded, it will use the macros declared in resources.cfg
+    _DOMAIN                         $DOMAIN$
+    _DOMAINUSERSHORT                $DOMAINUSERSHORT$
+    _DOMAINUSER                     $_HOSTDOMAIN$\\$_HOSTDOMAINUSERSHORT$
+    _DOMAINPASSWORD                 $DOMAINPASSWORD$
+
+    _WINDOWS_DISK_WARN              90
+    _WINDOWS_DISK_CRIT              95
+    _WINDOWS_EVENT_LOG_WARN         1
+    _WINDOWS_EVENT_LOG_CRIT         2
+    _WINDOWS_REBOOT_WARN            15min:
+    _WINDOWS_REBOOT_CRIT            5min:
+    _WINDOWS_MEM_WARN               90
+    _WINDOWS_MEM_CRIT               95
+    _WINDOWS_ALL_CPU_WARN           80
+    _WINDOWS_ALL_CPU_CRIT           90
+    _WINDOWS_CPU_WARN               80
+    _WINDOWS_CPU_CRIT               90
+    _WINDOWS_LOAD_WARN              10
+    _WINDOWS_LOAD_CRIT              20
+    _WINDOWS_NET_WARN               80
+    _WINDOWS_NET_CRIT               90
+    _WINDOWS_EXCLUDED_AUTO_SERVICES
+    _WINDOWS_AUTO_SERVICES_WARN     0
+    _WINDOWS_AUTO_SERVICES_CRIT     1
+    _WINDOWS_BIG_PROCESSES_WARN     25
+
+    #Default Network Interface
+    _WINDOWS_NETWORK_INTERFACE      Ethernet
+
+    # Now some alert level for a windows host
+    _WINDOWS_SHARE_WARN             90
+    _WINDOWS_SHARE_CRIT             95
+}
+
+
+define service{
+    name                            windows-wmi-service
+    use                             generic-service
+    register                        0
+
+    aggregation                     system
+
+    servicegroups                   wmi
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/alignak_glpi.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/alignak_glpi.cfg
@@ -1,0 +1,8 @@
+define host{
+    use                     linux-nrpe
+    contact_groups          admins
+    host_name               alignak_glpi
+    alias                   Glpi / Alignak
+    display_name            Glpi / Alignak (Demo)
+    address                 176.31.224.51
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/always_down.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/always_down.cfg
@@ -1,0 +1,13 @@
+define host{
+    use                             linux-snmp
+    contact_groups                  admins
+    host_name                       always_down
+    alias                           Always down
+    address                         192.168.0.1
+
+    hostgroups                      monitoring_servers
+
+    # GPS
+    _LOC_LAT                        43.542780
+    _LOC_LNG                        1.510058
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/cogny.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/cogny.cfg
@@ -1,0 +1,21 @@
+define host{
+    use                             linux-snmp, http, https, dns
+    contact_groups                  admins, users
+    host_name                       cogny
+    alias                           Cogny
+    display_name                    Cogny (GLPI)
+    address                         93.93.47.81
+
+    hostgroups                      monitoring_servers
+
+    # GPS
+    _LOC_LAT                        43.542780
+    _LOC_LNG                        1.510058
+
+    # Web site configuration
+    _CHECK_HTTPS_DOMAIN_NAME        $HOSTADDRESS$
+    _CHECK_HTTPS_PORT               443
+    _CHECK_HTTPS_URI                /
+    _CHECK_HTTPS_AUTH               #login:password
+    _CHECK_HTTPS_MINIMUM_DAYS       30
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/denice.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/denice.cfg
@@ -1,0 +1,20 @@
+define host{
+    use                             linux-nrpe, http, https, dns
+    contact_groups                  admins
+    host_name                       denice
+    alias                           Denice (Shinken)
+    address                         93.93.47.82
+
+    hostgroups                      monitoring_servers
+
+    # GPS
+    _LOC_LAT                        43.542780
+    _LOC_LNG                        1.510058
+
+    # Web site configuration
+    _CHECK_HTTPS_DOMAIN_NAME        $HOSTADDRESS$
+    _CHECK_HTTPS_PORT               7767
+    _CHECK_HTTPS_URI                /
+    _CHECK_HTTPS_AUTH               #login:password
+    _CHECK_HTTPS_MINIMUM_DAYS       30
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/lachassagne.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/lachassagne.cfg
@@ -1,0 +1,13 @@
+define host{
+    use                             linux-nrpe
+    contact_groups                  admins
+    host_name                       lachassagne
+    alias                           Lachassagne (Database)
+    address                         93.93.47.83
+
+    hostgroups                      monitoring_servers
+
+    # GPS
+    _LOC_LAT                        43.542780
+    _LOC_LNG                        1.510058
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/montmelas.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/hosts/montmelas.cfg
@@ -1,0 +1,13 @@
+define host{
+    use                             linux-nrpe
+    contact_groups                  admins
+    host_name                       montmelas
+    alias                           Montmelas (ElasticSearch)
+    address                         107.191.47.221
+
+    hostgroups                      monitoring_servers
+
+    # GPS
+    _LOC_LAT                        43.542780
+    _LOC_LNG                        1.510058
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/readme.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/All/readme.cfg
@@ -1,0 +1,4 @@
+#
+# Only what concerns the All realm
+#
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/contacts/contacts.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/contacts/contacts.cfg
@@ -1,0 +1,34 @@
+# Contact definition
+# By default the contact will ask notification by mails
+define contact{
+    name                            north-contact
+    host_notifications_enabled	    1
+    service_notifications_enabled   1
+    email                           alignak@localhost
+    can_submit_commands		    1
+    notificationways        	    email
+    register                        0
+}
+
+define contactgroup{
+    contactgroup_name               north
+    alias                           North contacts
+}
+
+# This is a North contact
+define contact{
+    use                             north-contact
+    contact_name                    northman
+    alias                           North (fake to Fred)
+    email                           north.contact@alignak.com
+    pager                           0600000000   ; contact phone number
+    password                        north
+    is_admin                        0
+    can_submit_commands             1
+
+    contactgroups                   north
+
+    # User address6 to set the user's realm when he is imported in the backend
+    address6                        North
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/broker-north.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/broker-north.cfg
@@ -1,0 +1,48 @@
+#===============================================================================
+# BROKER (S1_Broker)
+#===============================================================================
+# Description: The broker is responsible for:
+# - Exporting centralized logs of all Alignak daemon processes
+# - Exporting status data
+# - Exporting performance data
+# - Exposing Alignak APIs:
+#   - Status data
+#   - Performance data
+#   - Configuration data
+#   - Command interface
+# https://alignak.readthedocs.org/en/latest/08_configobjects/broker.html
+#===============================================================================
+define broker {
+    broker_name             broker-north
+    address                 127.0.0.1
+    port                    17772
+
+    ## Realm
+    realm                   North
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_broker      = update the live state in the Alignak backend
+    modules                 backend_broker
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_arbiters         1   ; Take data from Arbiter. There should be only one
+                                ; broker for the arbiter.
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/brokerd-north.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/brokerd-north.ini
@@ -1,0 +1,43 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/brokerd-north.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=17772
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/brokerd-north.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING
+
+#-- External modules watchdog --
+# If a module got a brok queue() higher than this value, it will be
+# killed and restart. Put to 0 to disable it
+max_queue_size=100000
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/poller-north.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/poller-north.cfg
@@ -1,0 +1,58 @@
+#===============================================================================
+# POLLER (S1_Poller)
+#===============================================================================
+# Description: The poller is responsible for:
+# - Active data acquisition
+# - Local passive data acquisition
+# https://alignak.readthedocs.org/en/latest/08_configobjects/poller.html
+#===============================================================================
+define poller {
+    poller_name             poller-north
+    address                 127.0.0.1
+    port                    17771
+
+    ## Realm
+    realm                   North
+
+    ## Modules
+    # Default: None
+    ## Interesting modules:
+    # - booster-nrpe        = Replaces the check_nrpe binary. Therefore it
+    #                       enhances performances when there are lot of NRPE
+    #                       calls.
+    # - named-pipe          = Allow the poller to read a nagios.cmd named pipe.
+    #                       This permits the use of distributed check_mk checks
+    #                       should you desire it.
+    # - snmp-booster        = Snmp bulk polling module
+    modules
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    ## In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced parameters:
+    manage_sub_realms       0   ; Does it take jobs from schedulers of sub-Realms?
+    min_workers             0   ; Starts with N processes (0 = 1 per CPU)
+    max_workers             0   ; No more than N processes (0 = 1 per CPU)
+    processes_by_worker     256 ; Each worker manages N checks
+    polling_interval        1   ; Get jobs from schedulers each N seconds
+
+    #passive                0   ; For DMZ monitoring, set to 1 so the connections
+                                ; will be from scheduler -> poller.
+
+    # Poller tags are the tag that the poller will manage. Use None as tag name to manage
+    # untagged checks
+    #poller_tags             None
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/pollerd-north.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/pollerd-north.ini
@@ -1,0 +1,38 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/pollerd-north.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=17771
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/pollerd-north.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/receiver-north.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/receiver-north.cfg
@@ -1,0 +1,42 @@
+#===============================================================================
+# RECEIVER
+#===============================================================================
+# The receiver manages passive information. It's just a "buffer" which will
+# load passive modules (like NSCA) and be read by the arbiter to dispatch data.
+#===============================================================================
+define receiver {
+    receiver_name           receiver-north
+    address                 127.0.0.1
+    port                    17773
+
+    ## Realm
+    realm                   North
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - nsca                = NSCA protocol server for collecting passive checks
+    modules                 nsca_north
+
+    ## Optional parameters
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Feature
+    direct_routing          1   ; If enabled, it will directly send commands to the
+                                ; schedulers if it knows about the hostname in the
+                                ; command.
+                                ; If not the arbiter will get the information from
+                                ; the receiver.
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/receiverd-north.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/receiverd-north.ini
@@ -1,0 +1,38 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/receiverd-north.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=17773
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/usr/local/etc/alignak/certs/ca.pem
+#server_cert=/usr/local/etc/alignak/certs/server.cert
+#server_key=/usr/local/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/receiverd-north.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/scheduler-north.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/scheduler-north.cfg
@@ -1,0 +1,55 @@
+#===============================================================================
+# SCHEDULER (S1_Scheduler)
+#===============================================================================
+# The scheduler is a "Host manager". It gets the hosts and their services,
+# schedules the checks and transmit them to the pollers.
+# Description: The scheduler is responsible for:
+# - Creating the dependancy tree
+# - Scheduling checks
+# - Calculating states
+# - Requesting actions from a reactionner
+# - Buffering and forwarding results its associated broker
+# https://alignak.readthedocs.org/en/latest/08_configobjects/scheduler.html
+#===============================================================================
+define scheduler {
+    scheduler_name          scheduler-north
+    address                 127.0.0.1
+    port                    17768
+
+    ## Realm
+    realm                   North
+
+    ## Modules
+    # Default: None
+    # Interesting modules that can be used:
+    # - backend_scheduler   = store the live state in the Alignak backend (retention)
+    #modules                 backend_scheduler
+
+    ## Optional parameters:
+    timeout                 3   ; Ping timeout
+    data_timeout            120 ; Data send timeout
+    max_check_attempts      3   ; If ping fails N or more, then the node is dead
+    check_interval          60  ; Ping node every N seconds
+
+    # In a HA architecture this daemon can be a spare
+    spare                   0   ; 1 = is a spare, 0 = is not a spare
+
+    # Enable https or not
+    use_ssl	                0
+    # enable certificate/hostname check, will avoid man in the middle attacks
+    hard_ssl_name_check     0
+
+    ## Advanced Features:
+    # Skip initial broks creation. Boot fast, but some broker modules won't
+    # work with it! (like livestatus for example)
+    skip_initial_broks      0
+
+    # Some schedulers can manage more hosts than others
+    weight                  1
+
+    # In NATted environments, you declare each satellite ip[:port] as seen by
+    # *this* scheduler (if port not set, the port declared by satellite itself
+    # is used)
+    #satellitemap    poller-1=1.2.3.4:7771, reactionner-1=1.2.3.5:7769, ...
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/schedulerd-north.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/daemons/schedulerd-north.ini
@@ -1,0 +1,42 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/schedulerd-north.pid
+
+#-- Username and group to run
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=17768
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+
+# To be changed, to match your real modules directory installation
+#modulesdir=modules
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/etc/alignak/certs/ca.pem
+#server_cert=/etc/alignak/certs/server.cert
+#server_key=/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/schedulerd-north.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/hosts/passive-hosts.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/hosts/passive-hosts.cfg
@@ -1,0 +1,14 @@
+define host{
+    use                     north-host
+    host_name               passive-01
+    alias                   Passive host 1
+    address                 0.0.0.0
+}
+
+define host{
+    use                     north-host
+    host_name               passive-02
+    alias                   Passive host 2
+    address                 0.0.0.0
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/modules/mod-nsca-north.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/modules/mod-nsca-north.cfg
@@ -1,0 +1,47 @@
+## Module:      nsca
+## Loaded by:   Receiver
+# Receive check results sent with NSCA protocol.
+define module {
+    module_alias             nsca_north
+    python_name              alignak_module_nsca
+
+    # Default is listening on all address, TCP port 5667
+    host                    *
+    port                    5667
+
+    # Encryption method:
+    # 0 for no encryption (default)
+    # 1 for simple Xor
+    # No other encryption method available!
+    encryption_method       1
+    password                Alignak-2016
+
+    # Maximum packet age defines the maximum delay
+    # (in seconds) for a packet to be considered as staled
+    max_packet_age          60
+
+    # If check_future_packet attribute is defined, packets
+    # more recent than current timestamp are dropped
+    check_future_packet     1
+
+    # Payload length is length of effective data sent :
+    # . -1 to accept any payload length
+    # . 512 or 4096 depending upon NSCA client configuration
+    # If packet payload is not the right size, packet is dropped
+    payload_length          -1
+
+    # Buffer length is maximum length of received data :
+    # should be greater than payload length
+    # Default is 8192
+    #buffer_length           8192
+
+    # backlog is the maximum number of concurrent sockets
+    # Default is 10
+    #backlog                 10
+
+    # Packet output decoding codec
+    # NSCA packet output is decoded with this codec. Set this parameter to the right value
+    # for NSCA client using specific codecs for sending output data
+    # Default is UTF-8
+    #output_decoding         UTF-8
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/readme.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/readme.cfg
@@ -1,0 +1,4 @@
+#
+# Only what concerns the North realm
+#
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/realm.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/North/realm.cfg
@@ -1,0 +1,4 @@
+define realm {
+    realm_name    North
+    alias         North country
+}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/South/readme.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/South/readme.cfg
@@ -1,0 +1,4 @@
+#
+# Not yet defined
+#
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/South/realm.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/realms/South/realm.cfg
@@ -1,0 +1,5 @@
+define realm {
+    realm_name    South
+    alias         South country
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/resource.d/paths.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/resource.d/paths.cfg
@@ -1,0 +1,7 @@
+# Nagios legacy macros
+$USER1$=$NAGIOSPLUGINSDIR$
+$NAGIOSPLUGINSDIR$=/usr/lib/nagios/plugins
+
+#-- Location of the plugins for Alignak
+$PLUGINSDIR$=/usr/local/var/libexec/alignak
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/business-impacts.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/business-impacts.cfg
@@ -1,0 +1,81 @@
+# Some business impact templates
+# ------------------------------
+# The default value for business impact is 2, meaning "normal".
+
+define host{
+    register                0
+    name                    no-importance
+    business_impact         0
+    # Disable notifications
+    notifications_enabled   0
+}
+
+define host{
+    register                0
+    name                    qualification
+    business_impact         1
+}
+
+define host{
+    register                0
+    name                    normal
+    business_impact         3
+}
+
+define host{
+    register                0
+    name                    production
+    business_impact         3
+}
+
+define host{
+    register                0
+    name                    important
+    business_impact         4
+}
+
+define host{
+    register                0
+    name                    top-for-business
+    business_impact         5
+}
+
+
+define service{
+    register                0
+    name                    no-importance
+    business_impact         0
+    # Disable notifications
+    notifications_enabled   0
+}
+
+define service{
+    register                0
+    name                    qualification
+    business_impact         1
+}
+
+define service{
+    register                0
+    name                    normal
+    business_impact         3
+}
+
+define service{
+    register                0
+    name                    production
+    business_impact         3
+}
+
+define service{
+    register                0
+    name                    important
+    business_impact         4
+}
+
+define service{
+    register                0
+    name                    top-for-business
+    business_impact         5
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/generic-contact.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/generic-contact.cfg
@@ -1,0 +1,11 @@
+# Contact definition
+# By default the contact will ask notification by mails
+define contact{
+        name                            generic-contact
+	host_notifications_enabled	1
+	service_notifications_enabled	1
+	email				alignak@localhost
+	can_submit_commands		1
+	notificationways        	email
+        register                        0
+	}

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/generic-host.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/generic-host.cfg
@@ -1,0 +1,42 @@
+# Generic host definition template - This is NOT a real host, just a template!
+# Most hosts should inherit from this one
+define host{
+    name                    generic-host
+
+    # Checking part
+    check_command           _internal_host_up
+    max_check_attempts      2
+    check_interval          5
+
+    # Check every time
+    active_checks_enabled   1
+    check_period            24x7
+
+    # Notification part
+    # One notification each day (1440 = 60min* 24h)
+    # every time, and for all 'errors'
+    # notify the admins contactgroups by default
+    contact_groups          admins,users
+    notification_interval   1440
+    notification_period     24x7
+    notification_options    d,u,r,f
+    notifications_enabled   1
+
+    # Advanced option
+    event_handler_enabled   0
+    flap_detection_enabled  1
+    process_perf_data       1
+    snapshot_enabled        0
+
+    # Maintenance / snapshot period
+    #maintenance_period      none
+    #snapshot_period         none
+
+    # Dispatching
+    #poller_tag          DMZ
+    #realm               All
+
+    # This to say that it's a template
+    register            0
+}
+

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/generic-service.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/generic-service.cfg
@@ -1,0 +1,20 @@
+# Generic service definition template - This is NOT a real service, just a template!
+define service{
+        name                            generic-service         ; The 'name' of this service template
+        active_checks_enabled           1                       ; Active service checks are enabled
+        passive_checks_enabled          1                       ; Passive service checks are enabled/accepted
+        notifications_enabled           1                       ; Service notifications are enabled
+        notification_interval           1440
+        notification_period             24x7
+        event_handler_enabled           0                       ; Service event handler is enabled
+        flap_detection_enabled          1                       ; Flap detection is enabled
+        process_perf_data               1                       ; Process performance data
+        is_volatile                     0                       ; The service is not volatile
+        check_period                    24x7                    ; The service can be checked at any time of the day
+        max_check_attempts              3                       ; Re-check the service up to 3 times in order to determine its final (hard) state
+        check_interval                  5                       ; Check the service every 5 minutes under normal conditions
+        retry_interval                  2                       ; Re-check the service every two minutes until a hard state can be determined
+        notification_options            w,u,c,r                 ; Send notifications about warning, unknown, critical, and recovery events
+        contact_groups                  admins,users
+        register                        0                       ; DONT REGISTER THIS DEFINITION - ITS NOT A REAL SERVICE, JUST A TEMPLATE
+        }

--- a/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/time_templates.cfg
+++ b/test/alignak_cfg_files/alignak_most_recent/arbiter/templates/time_templates.cfg
@@ -1,0 +1,231 @@
+##############################################################################
+##############################################################################
+#                                                                            
+# Different Time Check Interval Services
+#                                                                            
+##############################################################################
+##############################################################################
+
+##############################################################################
+# Purpose of time templates :
+# Simply define checks behavior of services with time template to avoid
+# false alerts.
+# There are three time template type : short, medium, long
+# - short means that it will be no retry check for service to be in hard state
+# - medium let a time period in soft state for service that can have peak load
+# - long let a greater time period in soft state, meant to service where
+# great variation and long charge time period are usual.
+##############################################################################
+
+# Check every 5min with immediate hard state
+define service{
+        name                            5min_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           5
+        retry_interval                  2
+        register                        0
+}
+
+# Check every 5min with hard state 3min after first non-OK detection
+define service{
+        name                            5min_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           5
+        retry_interval                  3
+        register                        0
+}
+
+# Check every 5min with hard state after 30min
+define service{
+        name                            5min_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           5
+        retry_interval                  5
+        register                        0
+}
+
+# Check every 10min with immediate hard state
+define service{
+        name                            10min_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           10
+        retry_interval                  5
+        register                        0
+}
+
+# Check every 10min with hard state 10min after first non-OK detection
+define service{
+        name                            10min_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           10
+        retry_interval                  10
+        register                        0
+}
+
+# Check every 10min with hard state after 1hour
+define service{
+        name                            10min_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           10
+        retry_interval                  10
+        register                        0
+}
+
+# Check every 20min with immediate hard state
+define service{
+        name                            20min_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           20 
+        retry_interval                  1
+        register                        0
+}
+
+# Check every 20min with hard state 20min after first non-OK detection
+define service{
+        name                            20min_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           20 
+        retry_interval                  20
+        register                        0
+}
+
+# Check every 20min with hard state after 2hours
+define service{
+        name                            20min_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           20 
+        retry_interval                  20
+        register                        0
+}
+
+# Check every 30min with immediate hard state
+define service{
+        name                            30min_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           30
+        retry_interval                  15
+        register                        0
+}
+
+# Check every 30min with hard state 30min after first non-OK detection
+define service{
+        name                            30min_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           30
+        retry_interval                  30
+        register                        0
+}
+
+# Check every 30min with hard state after 6hours
+define service{
+        name                            30min_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           30
+        retry_interval                  30
+        register                        0
+}
+
+# Check every 1hour with immediate hard state
+define service{
+        name                            1hour_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           60
+        retry_interval                  20
+        register                        0
+
+}
+
+# Check every 1hour with hard state 1hour after first non-OK detection
+define service{
+        name                            1hour_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           60
+        retry_interval                  60
+        register                        0
+
+}
+
+# Check every 1hour with hard state after 6hours
+define service{
+        name                            1hour_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           60
+        retry_interval                  60
+        register                        0
+
+}
+
+# Check every 12hours with immediate hard state
+define service{
+        name                            12hours_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           720
+        retry_interval                  360
+        register                        0
+}
+
+# Check every 12hours with hard state 12hours after first non-OK detection
+define service{
+        name                            12hours_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           720
+        retry_interval                  720
+        register                        0
+}
+
+# Check every 12hours with hard state after 3days
+define service{
+        name                            12hours_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           720
+        retry_interval                  720
+        register                        0
+}
+
+# Check every weeks with immediate hard state
+define service{
+        name                            1week_short
+        use                             generic-service
+        max_check_attempts              1
+        normal_check_interval           10080
+        retry_interval                  10
+        register                        0
+}
+
+# Check every weeks with hard state 1 week after first non-OK detection
+define service{
+        name                            1week_medium
+        use                             generic-service
+        max_check_attempts              2
+        normal_check_interval           10080
+        retry_interval                  10080
+        register                        0
+}
+
+# Check every weeks with hard state after 4 weeks
+define service{
+        name                            1week_long
+        use                             generic-service
+        max_check_attempts              6
+        normal_check_interval           10080
+        retry_interval                  10080
+        register                        0
+}

--- a/test/alignak_cfg_files/alignak_most_recent/certs/README
+++ b/test/alignak_cfg_files/alignak_most_recent/certs/README
@@ -1,0 +1,7 @@
+# Store your KPI/Certs in this directory as it is referenced in the daemons
+# configuration files
+
+# To generate new keys:
+openssl req -new -nodes -out server-req.pem -keyout private/server-key.pem -config /etc/ssl/openssl.cnf
+openssl ca -config openssl.conf -out server-cert.pem -infiles server-req.pem
+

--- a/test/alignak_cfg_files/alignak_most_recent/daemons/arbiterd.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/daemons/arbiterd.ini
@@ -1,0 +1,44 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/arbiterd.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7770
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/usr/local/etc/alignak/certs/ca.pem
+#server_cert=/usr/local/etc/alignak/certs/server.cert
+#server_key=/usr/local/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+#use_local_log=1
+local_log=/usr/local/var/log/alignak/arbiterd.log
+# Log with a formatted human date
+#human_timestamp_log=1
+#human_date_format=%Y-%m-%d %H:%M:%S %Z
+# Rotate log file every day, keeping 7 files
+#log_rotation_when=midnight
+#log_rotation_interval=1
+#log_rotation_count=7
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=INFO

--- a/test/alignak_cfg_files/alignak_most_recent/daemons/brokerd.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/daemons/brokerd.ini
@@ -1,0 +1,43 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/brokerd.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7772
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/usr/local/etc/alignak/certs/ca.pem
+#server_cert=/usr/local/etc/alignak/certs/server.cert
+#server_key=/usr/local/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/brokerd.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING
+#human_timestamp_log=1
+
+#-- External modules watchdog --
+# If a module got a brok queue() higher than this value, it will be
+# killed and restart. Put to 0 to disable it
+max_queue_size=100000

--- a/test/alignak_cfg_files/alignak_most_recent/daemons/pollerd.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/daemons/pollerd.ini
@@ -1,0 +1,38 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/pollerd.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7771
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/usr/local/etc/alignak/certs/ca.pem
+#server_cert=/usr/local/etc/alignak/certs/server.cert
+#server_key=/usr/local/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/pollerd.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING
+#human_timestamp_log=1

--- a/test/alignak_cfg_files/alignak_most_recent/daemons/reactionnerd.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/daemons/reactionnerd.ini
@@ -1,0 +1,38 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/reactionnerd.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7769
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/usr/local/etc/alignak/certs/ca.pem
+#server_cert=/usr/local/etc/alignak/certs/server.cert
+#server_key=/usr/local/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/reactionnerd.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING
+#human_timestamp_log=1

--- a/test/alignak_cfg_files/alignak_most_recent/daemons/receiverd.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/daemons/receiverd.ini
@@ -1,0 +1,38 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/receiverd.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7773
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/usr/local/etc/alignak/certs/ca.pem
+#server_cert=/usr/local/etc/alignak/certs/server.cert
+#server_key=/usr/local/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/receiverd.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+log_level=WARNING
+#human_timestamp_log=1

--- a/test/alignak_cfg_files/alignak_most_recent/daemons/schedulerd.ini
+++ b/test/alignak_cfg_files/alignak_most_recent/daemons/schedulerd.ini
@@ -1,0 +1,42 @@
+[daemon]
+
+#-- Path Configuration
+# The daemon will chdir into the directory workdir when launched
+# paths variables values, if not absolute paths, are relative to workdir.
+# using default values for following config variables value:
+workdir=/usr/local/var/run/alignak
+logdir=/usr/local/var/log/alignak
+
+pidfile=/usr/local/var/run/alignak/schedulerd.pid
+
+#-- Username and group to run (defaults to current user)
+#user=alignak
+#group=alignak
+
+#-- Network configuration
+# host=0.0.0.0
+port=7768
+# idontcareaboutsecurity=0
+
+#-- Set to 0 if you want to make this daemon NOT run
+daemon_enabled=1
+
+
+# To be changed, to match your real modules directory installation
+#modulesdir=modules
+
+#-- SSL configuration --
+use_ssl=0
+# WARNING : Put full paths for certs
+#ca_cert=/usr/local/etc/alignak/certs/ca.pem
+#server_cert=/usr/local/etc/alignak/certs/server.cert
+#server_key=/usr/local/etc/alignak/certs/server.key
+#hard_ssl_name_check=0
+
+#-- Local log management --
+# Enabled by default to ease troubleshooting
+use_local_log=1
+local_log=/usr/local/var/log/alignak/schedulerd.log
+# accepted log level values= DEBUG,INFO,WARNING,ERROR,CRITICAL
+#log_level=WARNING
+#human_timestamp_log=1

--- a/test/test_cfg_to_backend.py
+++ b/test/test_cfg_to_backend.py
@@ -46,8 +46,15 @@ class TestCfgToBackend(unittest2.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.backend.delete("user", {})
-        cls.pid.kill()
+        """
+        Stop alignak backend
+
+        :return: None
+        """
+        cls.backend.delete("host", {})
+
+        subprocess.call(['uwsgi', '--stop', '/tmp/uwsgi.pid'])
+        time.sleep(2)
 
     @classmethod
     def tearDown(cls):
@@ -544,7 +551,13 @@ class TestContactsNW(unittest2.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.pid.kill()
+        """
+        Stop alignak backend
+
+        :return: None
+        """
+        subprocess.call(['uwsgi', '--stop', '/tmp/uwsgi.pid'])
+        time.sleep(2)
 
     def test_user_notification_ways(self):
         q = subprocess.Popen(['../alignak_backend_import/cfg_to_backend.py', '--delete',
@@ -615,7 +628,13 @@ class TestContacts(unittest2.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.pid.kill()
+        """
+        Stop alignak backend
+
+        :return: None
+        """
+        subprocess.call(['uwsgi', '--stop', '/tmp/uwsgi.pid'])
+        time.sleep(2)
 
     def test_user_direct_notification(self):
         q = subprocess.Popen(['../alignak_backend_import/cfg_to_backend.py', '--delete',
@@ -684,7 +703,13 @@ class TestHosts(unittest2.TestCase):
 
     @classmethod
     def tearDownClass(cls):
-        cls.pid.kill()
+        """
+        Stop alignak backend
+
+        :return: None
+        """
+        subprocess.call(['uwsgi', '--stop', '/tmp/uwsgi.pid'])
+        time.sleep(2)
 
     def test_hosts(self):
 

--- a/test/test_import_default.py
+++ b/test/test_import_default.py
@@ -40,20 +40,35 @@ class TestCfgToBackend(unittest2.TestCase):
     @classmethod
     def tearDownClass(cls):
         """
-        Kill uwsgi
+        Stop alignak backend
 
         :return: None
         """
         subprocess.call(['uwsgi', '--stop', '/tmp/uwsgi.pid'])
         time.sleep(2)
 
-    def testImport1(self):
+    def testImportShinken1(self):
         """
-        Import configuration with backend deletion
+        Import a complete shinken configuration
         :return:
         """
         print ("Feeding backend...")
         exit_code = subprocess.call(
-            shlex.split('alignak_backend_import --delete shinken_cfg_files/default/_main.cfg')
+            shlex.split('alignak_backend_import '
+                        '--delete shinken_cfg_files/default/_main.cfg')
+        )
+        assert exit_code == 0
+
+    def testImportAlignak1(self):
+        """
+        Import the alignak demo server configuration (updated after log + arbiter interface
+        modification)
+
+        :return:
+        """
+        print ("Feeding backend...")
+        exit_code = subprocess.call(
+            shlex.split('alignak_backend_import '
+                        '--delete alignak_cfg_files/alignak_most_recent/alignak.backend-import.cfg')
         )
         assert exit_code == 0


### PR DESCRIPTION
- Change Arbiter init function signature
- Add Alignak Arbiter configuration parsing logs in the output
- Clean tests for stopping uwsgi process
- Rename script as alignak-backend-import and makes old name as deprecated.
- Set version as 0.6.0