### PR TITLE
 adaption to python 3.8

### DIFF
--- a/alignak_backend_import/cfg_to_backend.py
+++ b/alignak_backend_import/cfg_to_backend.py
@@ -912,7 +912,7 @@ class CfgToBackend(object):  # pylint: disable=useless-object-inheritance
         source.update(addprop)
 
         # Second iteration after update of notification ways (#19)
-        for prop in source:
+        for prop in list(source):
             # Unique commands with arguments
             # Removed the event handlers and snapshot command parameters because of this issue:
             # https://github.com/Alignak-monitoring-contrib/alignak-backend/issues/119


### PR DESCRIPTION
The Iteration changes while  looping.
this cause an error in python 3.8
copying  the iteration variables into a list fixes this amd make it run with python3.8
